### PR TITLE
Maven Central badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@
     <a href="https://sonarcloud.io/summary/new_code?id=Qytera-Gmbh_QTAF">
         <img src="https://sonarcloud.io/api/project_badges/measure?project=Qytera-Gmbh_QTAF&metric=sqale_rating&token=a2bbe8b96ab480a3f4a4c1030d2d3192a622b239" alt="Sonarcloud Maintainability Rating">
     </a>
+    <a href="https://mvnrepository.com/artifact/de.qytera/qtaf-core/latest">
+        <img src="https://img.shields.io/maven-central/v/de.qytera/qtaf-core?style=flat" alt="Maven Central Version">
+    </a>
 </p>
 
 ## Table of contents


### PR DESCRIPTION
This PR adds a Maven Central badge to the README's header which will always redirect to the latest version of `qtaf-core`.

You can view the updated README at https://github.com/Qytera-Gmbh/QTAF/tree/feature/maven-badge.