### PR TITLE
Allow custom test statuses to be used in Xray configuration

### DIFF
--- a/qtaf-html-report-plugin/src/main/java/de/qytera/qtaf/htmlreport/creator/ReportCreator.java
+++ b/qtaf-html-report-plugin/src/main/java/de/qytera/qtaf/htmlreport/creator/ReportCreator.java
@@ -1,11 +1,11 @@
 package de.qytera.qtaf.htmlreport.creator;
 
-import com.mitchellbosecke.pebble.error.LoaderException;
-import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import de.qytera.qtaf.core.io.DirectoryHelper;
 import de.qytera.qtaf.core.log.model.collection.TestSuiteLogCollection;
 import de.qytera.qtaf.htmlreport.engine.TemplateEngine;
 import de.qytera.qtaf.htmlreport.events.QtafHtmlReportEvents;
+import io.pebbletemplates.pebble.error.LoaderException;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
 
 import java.io.IOException;
 import java.io.StringWriter;

--- a/qtaf-html-report-plugin/src/main/java/de/qytera/qtaf/htmlreport/engine/TemplateEngine.java
+++ b/qtaf-html-report-plugin/src/main/java/de/qytera/qtaf/htmlreport/engine/TemplateEngine.java
@@ -1,8 +1,8 @@
 package de.qytera.qtaf.htmlreport.engine;
 
-import com.mitchellbosecke.pebble.PebbleEngine;
-import com.mitchellbosecke.pebble.template.PebbleTemplate;
 
+import io.pebbletemplates.pebble.PebbleEngine;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
 
 /**
  * Template file rendering engine

--- a/qtaf-html-report-plugin/src/test/java/de/qytera/qtaf/htmlreport/TemplateRendererTest.java
+++ b/qtaf-html-report-plugin/src/test/java/de/qytera/qtaf/htmlreport/TemplateRendererTest.java
@@ -1,12 +1,12 @@
 package de.qytera.qtaf.htmlreport;
 
-import com.mitchellbosecke.pebble.PebbleEngine;
-import com.mitchellbosecke.pebble.error.LoaderException;
-import com.mitchellbosecke.pebble.template.PebbleTemplate;
 import de.qytera.qtaf.core.log.model.collection.TestSuiteLogCollection;
 import de.qytera.qtaf.htmlreport.creator.FeatureReportCreator;
 import de.qytera.qtaf.htmlreport.creator.ReportCreator;
 import de.qytera.qtaf.htmlreport.creator.ScenarioReportCreator;
+import io.pebbletemplates.pebble.PebbleEngine;
+import io.pebbletemplates.pebble.error.LoaderException;
+import io.pebbletemplates.pebble.template.PebbleTemplate;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/AbstractXrayJsonImportBuilder.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/AbstractXrayJsonImportBuilder.java
@@ -7,12 +7,12 @@ import de.qytera.qtaf.core.log.model.collection.TestSuiteLogCollection;
 import de.qytera.qtaf.core.log.model.error.ErrorLogCollection;
 import de.qytera.qtaf.core.log.model.message.LogMessage;
 import de.qytera.qtaf.core.log.model.message.StepInformationLogMessage;
+import de.qytera.qtaf.core.util.Base64Helper;
 import de.qytera.qtaf.htmlreport.creator.ScenarioReportCreator;
 import de.qytera.qtaf.xray.annotation.XrayTest;
 import de.qytera.qtaf.xray.config.XrayConfigHelper;
-import de.qytera.qtaf.xray.entity.*;
 import de.qytera.qtaf.xray.dto.request.XrayImportRequestDto;
-import de.qytera.qtaf.core.util.Base64Helper;
+import de.qytera.qtaf.xray.entity.*;
 import de.qytera.qtaf.xray.error.EvidenceUploadError;
 
 import java.io.IOException;
@@ -145,9 +145,9 @@ public abstract class AbstractXrayJsonImportBuilder {
 
                     // Set the scenario status
                     if (didScenarioPass) {
-                        xrayTestEntity.setStatus(XrayTestEntity.Status.PASSED);
+                        xrayTestEntity.setStatus(XrayTestEntity.Status.PASSED.value);
                     } else {
-                        xrayTestEntity.setStatus(XrayTestEntity.Status.FAILED);
+                        xrayTestEntity.setStatus(XrayTestEntity.Status.FAILED.value);
                     }
 
                     // Add test to test collection
@@ -343,10 +343,17 @@ public abstract class AbstractXrayJsonImportBuilder {
 
     /**
      * Set the test status for the Xray Test Entity based on the log data of a scenario
-     * @param scenarioLog       Log data of a scenario
-     * @param xrayTestEntity    Xray test entity
+     *
+     * @param scenarioLog    Log data of a scenario
+     * @param xrayTestEntity Xray test entity
      */
-    public abstract void setTestStatus(TestScenarioLogCollection scenarioLog, XrayTestEntity xrayTestEntity);
+    public void setTestStatus(TestScenarioLogCollection scenarioLog, XrayTestEntity xrayTestEntity) {
+        if (scenarioLog.getStatus() == TestScenarioLogCollection.Status.SUCCESS) {
+            xrayTestEntity.setStatus(XrayTestEntity.Status.PASSED.value);
+        } else {
+            xrayTestEntity.setStatus(XrayTestEntity.Status.FAILED.value);
+        }
+    }
 
     /**
      * Set the step status for the Xray Step Entity based on the log data of a step

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/AbstractXrayJsonImportBuilder.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/AbstractXrayJsonImportBuilder.java
@@ -145,9 +145,9 @@ public abstract class AbstractXrayJsonImportBuilder {
 
                     // Set the scenario status
                     if (didScenarioPass) {
-                        xrayTestEntity.setStatus(XrayTestEntity.Status.PASSED.value);
+                        xrayTestEntity.setStatus(XrayTestEntity.Status.passed().text);
                     } else {
-                        xrayTestEntity.setStatus(XrayTestEntity.Status.FAILED.value);
+                        xrayTestEntity.setStatus(XrayTestEntity.Status.failed().text);
                     }
 
                     // Add test to test collection

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/AbstractXrayJsonImportBuilder.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/AbstractXrayJsonImportBuilder.java
@@ -349,9 +349,9 @@ public abstract class AbstractXrayJsonImportBuilder {
      */
     public void setTestStatus(TestScenarioLogCollection scenarioLog, XrayTestEntity xrayTestEntity) {
         if (scenarioLog.getStatus() == TestScenarioLogCollection.Status.SUCCESS) {
-            xrayTestEntity.setStatus(XrayTestEntity.Status.PASSED.value);
+            xrayTestEntity.setStatus(XrayTestEntity.Status.passed().text);
         } else {
-            xrayTestEntity.setStatus(XrayTestEntity.Status.FAILED.value);
+            xrayTestEntity.setStatus(XrayTestEntity.Status.failed().text);
         }
     }
 

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/XrayCloudJsonImportBuilder.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/XrayCloudJsonImportBuilder.java
@@ -1,22 +1,12 @@
 package de.qytera.qtaf.xray.builder;
 
-import de.qytera.qtaf.core.log.model.collection.TestScenarioLogCollection;
 import de.qytera.qtaf.core.log.model.message.StepInformationLogMessage;
-import de.qytera.qtaf.xray.entity.XrayTestEntity;
 import de.qytera.qtaf.xray.entity.XrayManualTestStepResultEntity;
 
 /**
  * This service is responsible for building the Import DTO for the test execution for Xray Cloud
  */
 public class XrayCloudJsonImportBuilder extends AbstractXrayJsonImportBuilder {
-    @Override
-    public void setTestStatus(TestScenarioLogCollection scenarioLog, XrayTestEntity xrayTestEntity) {
-        if (scenarioLog.getStatus() == TestScenarioLogCollection.Status.SUCCESS) {
-            xrayTestEntity.setStatus(XrayTestEntity.Status.PASSED);
-        } else {
-            xrayTestEntity.setStatus(XrayTestEntity.Status.FAILED);
-        }
-    }
 
     @Override
     public void setStepStatus(StepInformationLogMessage stepLog, XrayManualTestStepResultEntity xrayTestStepEntity) {

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/XrayServerJsonImportBuilder.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/XrayServerJsonImportBuilder.java
@@ -1,22 +1,12 @@
 package de.qytera.qtaf.xray.builder;
 
-import de.qytera.qtaf.core.log.model.collection.TestScenarioLogCollection;
 import de.qytera.qtaf.core.log.model.message.StepInformationLogMessage;
-import de.qytera.qtaf.xray.entity.XrayTestEntity;
 import de.qytera.qtaf.xray.entity.XrayManualTestStepResultEntity;
 
 /**
  * This service is responsible for building the Import DTO for the test execution for Xray Server
  */
 public class XrayServerJsonImportBuilder extends AbstractXrayJsonImportBuilder {
-    @Override
-    public void setTestStatus(TestScenarioLogCollection scenarioLog, XrayTestEntity xrayTestEntity) {
-        if (scenarioLog.getStatus() == TestScenarioLogCollection.Status.SUCCESS) {
-            xrayTestEntity.setStatus(XrayTestEntity.Status.PASS);
-        } else {
-            xrayTestEntity.setStatus(XrayTestEntity.Status.FAIL);
-        }
-    }
 
     @Override
     public void setStepStatus(StepInformationLogMessage stepLog, XrayManualTestStepResultEntity xrayManualTestStepResultEntity) {

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/config/XrayConfigHelper.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/config/XrayConfigHelper.java
@@ -13,15 +13,15 @@ public class XrayConfigHelper {
     private static ConfigMap config = QtafFactory.getConfiguration();
 
     // Keys
-    private static String XRAY_SERVICE_SELECTOR = "xray.service";
+    public static final String XRAY_SERVICE_SELECTOR = "xray.service";
     private static String XRAY_SERVER_URL_SELECTOR = "xray.url";
     private static String BEARER_TOKEN_SELECTOR = "xray.authentication.bearerToken";
     private static String CLIENT_ID_SELECTOR = "xray.authentication.clientId";
     private static String CLIENT_SECRET_SELECTOR = "xray.authentication.clientSecret";
     private static String SCENARIO_REPORT_EVIDENCE = "xray.scenarioReportEvidence";
     private static String SCENARIO_IMAGE_EVIDENCE = "xray.scenarioImageEvidence";
-    private static final  String STATUS_PASSED_SELECTOR = "xray.status.passed";
-    private static final String STATUS_FAILED_SELECTOR = "xray.status.failed";
+    public static final  String STATUS_PASSED_SELECTOR = "xray.status.passed";
+    public static final String STATUS_FAILED_SELECTOR = "xray.status.failed";
 
     // Values
     private static String XRAY_SERVICE_CLOUD = "cloud";

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/config/XrayConfigHelper.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/config/XrayConfigHelper.java
@@ -20,6 +20,8 @@ public class XrayConfigHelper {
     private static String CLIENT_SECRET_SELECTOR = "xray.authentication.clientSecret";
     private static String SCENARIO_REPORT_EVIDENCE = "xray.scenarioReportEvidence";
     private static String SCENARIO_IMAGE_EVIDENCE = "xray.scenarioImageEvidence";
+    private static final  String STATUS_PASSED_SELECTOR = "xray.status.passed";
+    private static final String STATUS_FAILED_SELECTOR = "xray.status.failed";
 
     // Values
     private static String XRAY_SERVICE_CLOUD = "cloud";
@@ -55,6 +57,24 @@ public class XrayConfigHelper {
      */
     public static String getServerUrl() {
         return config.getString(XRAY_SERVER_URL_SELECTOR);
+    }
+
+    /**
+     * Get Xray status name for passed tests.
+     *
+     * @return the status name if configured, otherwise null
+     */
+    public static String getStatusPassed() {
+        return config.getString(STATUS_PASSED_SELECTOR);
+    }
+
+    /**
+     * Get Xray status name for failed tests.
+     *
+     * @return the status name if configured, otherwise null
+     */
+    public static String getStatusFailed() {
+        return config.getString(STATUS_FAILED_SELECTOR);
     }
 
     /**

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/entity/XrayTestEntity.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/entity/XrayTestEntity.java
@@ -1,5 +1,7 @@
 package de.qytera.qtaf.xray.entity;
 
+import de.qytera.qtaf.xray.config.XrayConfigHelper;
+
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -41,7 +43,7 @@ public class XrayTestEntity {
     /**
      * status
      */
-    private Status status;
+    private String status;
 
     /**
      * step logs
@@ -158,7 +160,7 @@ public class XrayTestEntity {
      *
      * @return status Status
      */
-    public Status getStatus() {
+    public String getStatus() {
         return status;
     }
 
@@ -238,7 +240,7 @@ public class XrayTestEntity {
      * @param status Status
      * @return this
      */
-    public XrayTestEntity setStatus(Status status) {
+    public XrayTestEntity setStatus(String status) {
         this.status = status;
         return this;
     }
@@ -394,13 +396,54 @@ public class XrayTestEntity {
         return this;
     }
 
+    private static String getStatusPassed() {
+        String status = XrayConfigHelper.getStatusPassed();
+        if (status != null) {
+            return status;
+        }
+        if (XrayConfigHelper.isXrayCloudService()) {
+            return "PASSED";
+        }
+        return "PASS";
+    }
+
+    private static String getStatusFailed() {
+        String status = XrayConfigHelper.getStatusFailed();
+        if (status != null) {
+            return status;
+        }
+        if (XrayConfigHelper.isXrayCloudService()) {
+            return "FAILED";
+        }
+        return "FAIL";
+    }
+
     /**
      * Status enum
      */
     public enum Status {
-        PASSED, // for xray cloud
-        PASS,   // for xray server
-        FAILED, // for xray cloud
-        FAIL    // for xray server
+        /**
+         * Represents the status of a test considered passed.
+         */
+        PASSED(getStatusPassed()),
+        /**
+         * Represents the status of a test considered failed.
+         */
+        FAILED(getStatusFailed());
+
+        /**
+         * The status value, e.g. {@code "PASSED"} or {@code "FAIL"}.
+         */
+        public final String value;
+
+        /**
+         * Construct a new Status with the given value.
+         *
+         * @param value the status value, such as {@code "PASS"} or {@code "FAILURE"}.
+         */
+        Status(String value) {
+            this.value = value;
+        }
+
     }
 }

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/entity/XrayTestEntity.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/entity/XrayTestEntity.java
@@ -396,53 +396,63 @@ public class XrayTestEntity {
         return this;
     }
 
-    private static String getStatusPassed() {
-        String status = XrayConfigHelper.getStatusPassed();
-        if (status != null) {
-            return status;
-        }
-        if (XrayConfigHelper.isXrayCloudService()) {
-            return "PASSED";
-        }
-        return "PASS";
-    }
-
-    private static String getStatusFailed() {
-        String status = XrayConfigHelper.getStatusFailed();
-        if (status != null) {
-            return status;
-        }
-        if (XrayConfigHelper.isXrayCloudService()) {
-            return "FAILED";
-        }
-        return "FAIL";
-    }
-
     /**
-     * Status enum
+     * Test status entity.
      */
-    public enum Status {
+    public static class Status {
         /**
-         * Represents the status of a test considered passed.
+         * The status of a test considered passed.
+         *
+         * @return the status
          */
-        PASSED(getStatusPassed()),
-        /**
-         * Represents the status of a test considered failed.
-         */
-        FAILED(getStatusFailed());
+        public static Status passed() {
+            return new Status(getStatusPassed());
+        }
 
         /**
-         * The status value, e.g. {@code "PASSED"} or {@code "FAIL"}.
+         * The status of a test considered failed.
+         *
+         * @return the status
          */
-        public final String value;
+        public static Status failed() {
+            return new Status(getStatusFailed());
+        }
+
+        /**
+         * The status value, e.g. {@code "PASSED"} or {@code "FAIL"}. Depends on the configured Xray instance.
+         */
+        public final String text;
 
         /**
          * Construct a new Status with the given value.
          *
-         * @param value the status value, such as {@code "PASS"} or {@code "FAILURE"}.
+         * @param text the status value, such as {@code "PASS"} or {@code "FAILURE"}.
          */
-        Status(String value) {
-            this.value = value;
+        private Status(String text) {
+            this.text = text;
+        }
+
+
+        private static String getStatusPassed() {
+            String status = XrayConfigHelper.getStatusPassed();
+            if (status != null) {
+                return status;
+            }
+            if (XrayConfigHelper.isXrayCloudService()) {
+                return "PASSED";
+            }
+            return "PASS";
+        }
+
+        private static String getStatusFailed() {
+            String status = XrayConfigHelper.getStatusFailed();
+            if (status != null) {
+                return status;
+            }
+            if (XrayConfigHelper.isXrayCloudService()) {
+                return "FAILED";
+            }
+            return "FAIL";
         }
 
     }

--- a/qtaf-xray-plugin/src/main/resources/de/qytera/qtaf/core/config/configuration.json
+++ b/qtaf-xray-plugin/src/main/resources/de/qytera/qtaf/core/config/configuration.json
@@ -1,1 +1,33 @@
-{  "driver": {    "name": "chrome",    "remoteUrl": null,    "quitAfterTesting": true,    "implicitWaitTimeout": 30  },  "logging": {    "enabled": true  },  "xray": {    "enabled": false,    "service": "cloud",    "url": "",    "scenarioReportEvidence": false,    "scenarioImageEvidence": false,    "authentication":{      "bearerToken": "",      "clientId": "",      "clientSecret": ""    }  },  "htmlReport": {    "enabled": true  },  "framework": {    "packageNames": [    ]  }}
+{
+  "driver": {
+    "name": "chrome",
+    "remoteUrl": null,
+    "quitAfterTesting": true,
+    "implicitWaitTimeout": 30
+  },
+  "logging": {
+    "enabled": true
+  },
+  "xray": {
+    "enabled": false,
+    "service": "cloud",
+    "url": "",
+    "scenarioReportEvidence": false,
+    "scenarioImageEvidence": false,
+    "authentication": {
+      "bearerToken": "",
+      "clientId": "",
+      "clientSecret": ""
+    },
+    "status": {
+      "passed": null,
+      "failed": null
+    }
+  },
+  "htmlReport": {
+    "enabled": true
+  },
+  "framework": {
+    "packageNames": []
+  }
+}

--- a/qtaf-xray-plugin/src/test/java/de/qytera/qtaf/xray/entity/XrayTestEntityTest.java
+++ b/qtaf-xray-plugin/src/test/java/de/qytera/qtaf/xray/entity/XrayTestEntityTest.java
@@ -1,0 +1,45 @@
+package de.qytera.qtaf.xray.entity;
+
+import de.qytera.qtaf.core.QtafFactory;
+import de.qytera.qtaf.core.config.entity.ConfigMap;
+import de.qytera.qtaf.xray.config.XrayConfigHelper;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class XrayTestEntityTest {
+
+    @BeforeMethod
+    public void clearConfigMap() {
+        ConfigMap configMap = QtafFactory.getConfiguration();
+        configMap.remove(XrayConfigHelper.XRAY_SERVICE_SELECTOR);
+        configMap.remove(XrayConfigHelper.STATUS_PASSED_SELECTOR);
+        configMap.remove(XrayConfigHelper.STATUS_FAILED_SELECTOR);
+    }
+
+    @Test
+    public void testStatusServer() {
+        ConfigMap configMap = QtafFactory.getConfiguration();
+        configMap.setString("xray.service", "server");
+        Assert.assertEquals(XrayTestEntity.Status.failed().text, "FAIL");
+        Assert.assertEquals(XrayTestEntity.Status.passed().text, "PASS");
+    }
+
+    @Test
+    public void testStatusCloud() {
+        ConfigMap configMap = QtafFactory.getConfiguration();
+        configMap.setString("xray.service", "cloud");
+        Assert.assertEquals(XrayTestEntity.Status.failed().text, "FAILED");
+        Assert.assertEquals(XrayTestEntity.Status.passed().text, "PASSED");
+    }
+
+    @Test
+    public void testStatusCustom() {
+        ConfigMap configMap = QtafFactory.getConfiguration();
+        configMap.setString("xray.status.passed", "SUCCESS");
+        configMap.setString("xray.status.failed", "FAILURE");
+        Assert.assertEquals(XrayTestEntity.Status.failed().text, "FAILURE");
+        Assert.assertEquals(XrayTestEntity.Status.passed().text, "SUCCESS");
+    }
+
+}


### PR DESCRIPTION
This PR allows users to provide custom test statuses such as `SUCCESS` or `FAILING` when uploading test results to Xray.