### PR TITLE
Allow truncation of long parameter names/values during Xray JSON construction

### DIFF
--- a/qtaf-core/src/main/resources/qtaf.json
+++ b/qtaf-core/src/main/resources/qtaf.json
@@ -32,7 +32,21 @@
       "bearerToken": null
     },
     "scenarioReportEvidence": true,
-    "scenarioImageEvidence": true
+    "scenarioImageEvidence": true,
+    "status": {
+      "passed": null,
+      "failed": null
+    },
+    "results": {
+      "iterations": {
+        "parameters": {
+          "maxLength": {
+            "name": null,
+            "value": null
+          }
+        }
+      }
+    }
   },
   "htmlReport": {
     "enabled": true

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/AbstractXrayJsonImportBuilder.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/AbstractXrayJsonImportBuilder.java
@@ -97,8 +97,8 @@ public abstract class AbstractXrayJsonImportBuilder {
                             // Add test parameters
                             for (TestScenarioLogCollection.TestParameter testParameter : scenarioLog.getTestParameters()) {
                                 XrayTestIterationParameterEntity parameterEntity = new XrayTestIterationParameterEntity();
-                                parameterEntity.setName(testParameter.getName());
-                                parameterEntity.setValue(testParameter.getValue().toString());
+                                parameterEntity.setName(truncateParameterName(testParameter.getName()));
+                                parameterEntity.setValue(truncateParameterValue(testParameter.getValue().toString()));
                                 iteration.addParameter(parameterEntity);
                             }
 
@@ -361,4 +361,21 @@ public abstract class AbstractXrayJsonImportBuilder {
      * @param xrayTestStepEntity    Xray Step Entity
      */
     public abstract void setStepStatus(StepInformationLogMessage stepLog, XrayManualTestStepResultEntity xrayTestStepEntity);
+
+    private static String truncateParameterName(String parameterName) {
+        Integer maxLength = XrayConfigHelper.getIterationParameterNameMaxLength();
+        if (maxLength == null || parameterName.length() <= maxLength) {
+            return parameterName;
+        }
+        return parameterName.substring(0, maxLength);
+    }
+
+    private static String truncateParameterValue(String parameterValue) {
+        Integer maxLength = XrayConfigHelper.getIterationParameterValueMaxLength();
+        if (maxLength == null || parameterValue.length() <= maxLength) {
+            return parameterValue;
+        }
+        return parameterValue.substring(0, maxLength);
+    }
+
 }

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/config/XrayConfigHelper.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/config/XrayConfigHelper.java
@@ -20,8 +20,10 @@ public class XrayConfigHelper {
     private static String CLIENT_SECRET_SELECTOR = "xray.authentication.clientSecret";
     private static String SCENARIO_REPORT_EVIDENCE = "xray.scenarioReportEvidence";
     private static String SCENARIO_IMAGE_EVIDENCE = "xray.scenarioImageEvidence";
-    public static final  String STATUS_PASSED_SELECTOR = "xray.status.passed";
+    public static final String STATUS_PASSED_SELECTOR = "xray.status.passed";
     public static final String STATUS_FAILED_SELECTOR = "xray.status.failed";
+    public static final String RESULTS_ITERATIONS_PARAMETERS_MAX_LENGTH_NAME = "xray.results.iterations.parameters.maxLength.name";
+    public static final String RESULTS_ITERATIONS_PARAMETERS_MAX_LENGTH_VALUE = "xray.results.iterations.parameters.maxLength.value";
 
     // Values
     private static String XRAY_SERVICE_CLOUD = "cloud";

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/config/XrayConfigHelper.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/config/XrayConfigHelper.java
@@ -124,4 +124,22 @@ public class XrayConfigHelper {
     public static boolean isScenarioImageEvidenceEnabled() {
         return config.getBoolean(SCENARIO_IMAGE_EVIDENCE);
     }
+
+    /**
+     * Returns the maximum allowed length of iteration parameter names.
+     *
+     * @return the maximum length or null if there is no maximum length
+     */
+    public static Integer getIterationParameterNameMaxLength() {
+        return config.getInt(RESULTS_ITERATIONS_PARAMETERS_MAX_LENGTH_NAME);
+    }
+
+    /**
+     * Returns the maximum allowed length of iteration parameter values.
+     *
+     * @return the maximum length or null if there is no maximum length
+     */
+    public static Integer getIterationParameterValueMaxLength() {
+        return config.getInt(RESULTS_ITERATIONS_PARAMETERS_MAX_LENGTH_VALUE);
+    }
 }

--- a/qtaf-xray-plugin/src/test/java/de/qytera/qtaf/xray/builder/AbstractXrayJsonImportBuilderTest.java
+++ b/qtaf-xray-plugin/src/test/java/de/qytera/qtaf/xray/builder/AbstractXrayJsonImportBuilderTest.java
@@ -1,0 +1,118 @@
+package de.qytera.qtaf.xray.builder;
+
+import de.qytera.qtaf.core.QtafFactory;
+import de.qytera.qtaf.core.config.entity.ConfigMap;
+import de.qytera.qtaf.core.log.model.collection.TestFeatureLogCollection;
+import de.qytera.qtaf.core.log.model.collection.TestScenarioLogCollection;
+import de.qytera.qtaf.core.log.model.collection.TestSuiteLogCollection;
+import de.qytera.qtaf.xray.annotation.XrayTest;
+import de.qytera.qtaf.xray.config.XrayConfigHelper;
+import de.qytera.qtaf.xray.dto.request.XrayImportRequestDto;
+import de.qytera.qtaf.xray.entity.XrayTestEntity;
+import de.qytera.qtaf.xray.entity.XrayTestIterationParameterEntity;
+import de.qytera.qtaf.xray.entity.XrayTestIterationResultEntity;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.lang.annotation.Annotation;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.List;
+
+public class AbstractXrayJsonImportBuilderTest {
+
+    private static final XrayTest ANNOTATION = new XrayTest() {
+
+        @Override
+        public String key() {
+            return "QTAF-42";
+        }
+
+        @Override
+        public boolean scenarioReport() {
+            return false;
+        }
+
+        @Override
+        public boolean screenshots() {
+            return false;
+        }
+
+        @Override
+        public Class<? extends Annotation> annotationType() {
+            return XrayTest.class;
+        }
+    };
+
+    private static TestScenarioLogCollection scenarioWithId(String id) {
+        TestScenarioLogCollection scenarioCollection = TestScenarioLogCollection.createTestScenarioLogCollection("feature-1", "scenario-1", id, "debug-scenario");
+        scenarioCollection.setStart(Date.from(Instant.now().minusSeconds(3600)));
+        scenarioCollection.setEnd(Date.from(Instant.now()));
+        scenarioCollection.setStatus(TestScenarioLogCollection.Status.SUCCESS);
+        scenarioCollection.setAnnotations(new Annotation[]{ANNOTATION});
+        return scenarioCollection;
+    }
+
+    @DataProvider(name = "longParameterValueProvider")
+    private Object[][] longParameterValueProvider() {
+        List<List<String>> expectedParameterValues = new ArrayList<>();
+
+        TestFeatureLogCollection featureCollection = TestFeatureLogCollection.createFeatureLogCollectionIfNotExists("feature-1", "feature-xray");
+
+        TestScenarioLogCollection scenarioCollection = scenarioWithId("1");
+        List<String> parameters = Arrays.asList(
+                "a",
+                "abcd",
+                "abcdefghijklmnop",
+                "abcdefghijklmnopqrstuvwxyz01234567891011121314151617181920212223"
+        );
+        scenarioCollection.addParameters(parameters.toArray());
+        featureCollection.addScenarioLogCollection(scenarioCollection);
+        expectedParameterValues.add(Arrays.asList("a", "abc", "abc", "abc"));
+
+        scenarioCollection = scenarioWithId("2");
+        parameters = Arrays.asList(
+                "ab",
+                "abcdefghi",
+                "abcdefghijklmnopqrstuvwxyz012345"
+        );
+        scenarioCollection.addParameters(parameters.toArray());
+        featureCollection.addScenarioLogCollection(scenarioCollection);
+        expectedParameterValues.add(Arrays.asList("ab", "abc", "abc"));
+
+        List<Object[]> data = new ArrayList<>();
+        for (AbstractXrayJsonImportBuilder builder : Arrays.asList(XrayJsonImportBuilderFactory.getServerInstance(), XrayJsonImportBuilderFactory.getCloudInstance())) {
+            data.add(new Object[]{
+                    builder,
+                    featureCollection,
+                    3,
+                    expectedParameterValues
+            });
+        }
+        return data.toArray(Object[][]::new);
+    }
+
+    @Test(dataProvider = "longParameterValueProvider")
+    public void testLongParameterValueTruncation(AbstractXrayJsonImportBuilder builder, TestFeatureLogCollection featureCollection, int maxLength, List<List<String>> expectedParameterValues) {
+        ConfigMap configMap = QtafFactory.getConfiguration();
+        configMap.setString(XrayConfigHelper.RESULTS_ITERATIONS_PARAMETERS_MAX_LENGTH_VALUE, String.valueOf(maxLength));
+
+        TestSuiteLogCollection suiteCollection = TestSuiteLogCollection.getInstance();
+        suiteCollection.addTestClassLogCollection(featureCollection);
+        XrayImportRequestDto dto = builder.buildFromTestSuiteLogs(suiteCollection);
+        XrayTestEntity test = dto.getTests().get(0);
+        List<List<String>> actualValues = new ArrayList<>();
+        for (XrayTestIterationResultEntity iteration : test.getIterations()) {
+            List<String> values = new ArrayList<>();
+            iteration.getParameters().stream()
+                    .map(XrayTestIterationParameterEntity::getValue)
+                    .forEach(values::add);
+            actualValues.add(values);
+        }
+        Assert.assertEquals(actualValues, expectedParameterValues);
+    }
+
+}

--- a/qtaf-xray-plugin/src/test/java/de/qytera/qtaf/xray/entity/XrayTestEntityTest.java
+++ b/qtaf-xray-plugin/src/test/java/de/qytera/qtaf/xray/entity/XrayTestEntityTest.java
@@ -20,7 +20,7 @@ public class XrayTestEntityTest {
     @Test
     public void testStatusServer() {
         ConfigMap configMap = QtafFactory.getConfiguration();
-        configMap.setString("xray.service", "server");
+        configMap.setString(XrayConfigHelper.XRAY_SERVICE_SELECTOR, "server");
         Assert.assertEquals(XrayTestEntity.Status.failed().text, "FAIL");
         Assert.assertEquals(XrayTestEntity.Status.passed().text, "PASS");
     }
@@ -28,7 +28,7 @@ public class XrayTestEntityTest {
     @Test
     public void testStatusCloud() {
         ConfigMap configMap = QtafFactory.getConfiguration();
-        configMap.setString("xray.service", "cloud");
+        configMap.setString(XrayConfigHelper.XRAY_SERVICE_SELECTOR, "cloud");
         Assert.assertEquals(XrayTestEntity.Status.failed().text, "FAILED");
         Assert.assertEquals(XrayTestEntity.Status.passed().text, "PASSED");
     }
@@ -36,8 +36,8 @@ public class XrayTestEntityTest {
     @Test
     public void testStatusCustom() {
         ConfigMap configMap = QtafFactory.getConfiguration();
-        configMap.setString("xray.status.passed", "SUCCESS");
-        configMap.setString("xray.status.failed", "FAILURE");
+        configMap.setString(XrayConfigHelper.STATUS_PASSED_SELECTOR, "SUCCESS");
+        configMap.setString(XrayConfigHelper.STATUS_FAILED_SELECTOR, "FAILURE");
         Assert.assertEquals(XrayTestEntity.Status.failed().text, "FAILURE");
         Assert.assertEquals(XrayTestEntity.Status.passed().text, "SUCCESS");
     }


### PR DESCRIPTION
This PR allows users to truncate very long iteration parameter names/values by setting a maximum length inside the `qtaf.json`.

It also fixes replaces some hardcoded strings with their corresponding constants.