### PR TITLE
Return `null` instead of 0 for undefined configuration integers

### DIFF
--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/config/entity/ConfigMap.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/config/entity/ConfigMap.java
@@ -141,23 +141,36 @@ public class ConfigMap extends HashMap<String, Object> {
     }
 
     /**
-     * Get int value from key
+     * Retrieves the value for the given key, interpreted as an {@link Integer}.
      *
-     * @param key   Key
-     * @return      Value
+     * @param key the key of the value to retrieve
+     * @return the key's value or null if there is no value
      */
     public Integer getInt(String key) {
         String s = this.getString(key);
-
-        try {
-            return Integer.parseInt(s);
-        } catch (Exception e) {
-            logger.error(
-                    "Value '" + s + "' of key '" + key + "' could not be parsed as integer"
-            );
-            this.errorLogCollection.addErrorLog(new ConfigurationError(e));
-            return 0;
+        if (s != null) {
+            try {
+                return Integer.parseInt(s);
+            } catch (Exception e) {
+                logger.error(String.format("Value '%s' of key '%s' could not be parsed as Integer", s, key));
+                this.errorLogCollection.addErrorLog(new ConfigurationError(e));
+                return null;
+            }
         }
+        return null;
+    }
+
+    /**
+     * Retrieves the value for the given key, interpreted as an {@link Integer}. If the value does not exist or is null,
+     * returns {@code valueIfNull} instead.
+     *
+     * @param key         the key of the value to retrieve
+     * @param valueIfNull the value to return if there is no value attached to the key
+     * @return the key's value or the provided default value
+     */
+    public Integer getInt(String key, Integer valueIfNull) {
+        Integer value = getInt(key);
+        return value == null ? valueIfNull : value;
     }
 
     /**

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/config/entity/ConfigMap.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/config/entity/ConfigMap.java
@@ -154,7 +154,6 @@ public class ConfigMap extends HashMap<String, Object> {
             } catch (Exception e) {
                 logger.error(String.format("Value '%s' of key '%s' could not be parsed as Integer", s, key));
                 this.errorLogCollection.addErrorLog(new ConfigurationError(e));
-                return null;
             }
         }
         return null;

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/helper/SeleniumDriverConfigHelper.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/helper/SeleniumDriverConfigHelper.java
@@ -34,18 +34,14 @@ public class SeleniumDriverConfigHelper {
     private static ConfigMap config = QtafFactory.getConfiguration();
 
     /**
-     * Configure driver properties
-     * @return  Driver object
+     * Retrieves the configured implicit timeout. Defaults to 30 seconds if no implicit timeout has been specified.
+     *
+     * @return the implicit timeout
+     * @see <a href="https://www.selenium.dev/documentation/webdriver/waits/#implicit-wait">https://www.selenium.dev/documentation/webdriver/waits/#implicit-wait</a>
      */
     public static int getImplicitTimeout() {
-        // Set implicit wait
-        int implicitTimeout = 30;
-
-        try {
-            implicitTimeout = config.getInt(DRIVER_IMPLICIT_WAIT_TIMEOUT);
-        } catch (Throwable ignored) {}
-
-        return implicitTimeout;
+        // Set implicit wait to 30 seconds by default.
+        return config.getInt(DRIVER_IMPLICIT_WAIT_TIMEOUT, 30);
     }
 
     /**

--- a/qtaf-core/src/test/java/de/qytera/qtaf/core/config/ConfigurationTest.java
+++ b/qtaf-core/src/test/java/de/qytera/qtaf/core/config/ConfigurationTest.java
@@ -125,4 +125,11 @@ public class ConfigurationTest {
         // Framework
         Assert.assertEquals(config.getArray("framework.packageNames").size(), 0);
     }
+
+    @Test
+    public void testGetInt() {
+        ConfigMap config = ConfigurationFactory.getInstance();
+        Assert.assertNull(config.getInt("hello.there"));
+        Assert.assertEquals(config.getInt("hello.there", 42), 42);
+    }
 }


### PR DESCRIPTION
This PR changes the behaviour of `config.getInt()` such that instead of returning 0 for unknown configuration keys, `null` is returned instead. This way, undefined configuration keys can be handled separately from defined ones.

For convenience, a second method was added as well which mimics the `getOrDefault()` behaviour of Java's `Map` class.