### PR TITLE
Add step screenshots as evidence inside iterations

### DIFF
--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/XrayJsonImportBuilder.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/XrayJsonImportBuilder.java
@@ -4,21 +4,16 @@ import com.google.inject.Singleton;
 import de.qytera.qtaf.core.log.model.collection.TestFeatureLogCollection;
 import de.qytera.qtaf.core.log.model.collection.TestScenarioLogCollection;
 import de.qytera.qtaf.core.log.model.collection.TestSuiteLogCollection;
-import de.qytera.qtaf.core.log.model.error.ErrorLogCollection;
 import de.qytera.qtaf.core.log.model.message.LogMessage;
 import de.qytera.qtaf.core.log.model.message.StepInformationLogMessage;
-import de.qytera.qtaf.core.util.Base64Helper;
 import de.qytera.qtaf.htmlreport.creator.ScenarioReportCreator;
 import de.qytera.qtaf.xray.annotation.XrayTest;
 import de.qytera.qtaf.xray.config.XrayConfigHelper;
 import de.qytera.qtaf.xray.dto.request.XrayImportRequestDto;
 import de.qytera.qtaf.xray.entity.*;
-import de.qytera.qtaf.xray.error.EvidenceUploadError;
 
-import java.io.IOException;
 import java.io.Writer;
 import java.lang.annotation.Annotation;
-import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -105,16 +100,7 @@ public class XrayJsonImportBuilder {
                                 for (LogMessage logMessage : scenarioLog.getLogMessages()) {
                                     // Only StepLogMessage entities are important for Xray
                                     if (logMessage instanceof StepInformationLogMessage stepLog) {
-                                        // Build step entity
-                                        XrayManualTestStepResultEntity xrayTestStepEntity = buildXrayManualTestStepResultEntity(stepLog);
-
-                                        // Add result to step
-                                        if (stepLog.getResult() != null) {
-                                            xrayTestStepEntity.setActualResult(stepLog.getResult().toString());
-                                        }
-
-                                        // Add step log to test log
-                                        iteration.addStep(xrayTestStepEntity);
+                                        iteration.addStep(buildXrayManualTestStepResultEntity(stepLog));
                                     }
                                 }
                             }
@@ -183,15 +169,6 @@ public class XrayJsonImportBuilder {
         return buildXrayTestEntity(collection, scenarioReportCreator, scenarioLog, xrayTestAnnotation);
     }
 
-    /**
-     * Build a XrayTestEntity object
-     *
-     * @param collection            test suite log collection
-     * @param scenarioReportCreator scenario report creator
-     * @param scenarioLog           test scenario log
-     * @param xrayTestAnnotation    XrayTest annotation
-     * @return Xray test entity instance
-     */
     private XrayTestEntity buildXrayTestEntity(
             TestSuiteLogCollection collection,
             ScenarioReportCreator scenarioReportCreator,
@@ -202,13 +179,18 @@ public class XrayJsonImportBuilder {
         XrayTestEntity xrayTestEntity = initializeXrayTestEntity(scenarioLog);
 
         // Add a scenario report to the xray test entity
-        if (xrayTestAnnotation.scenarioReport()) {
-            addScenarioReport(collection, scenarioReportCreator, scenarioLog, xrayTestEntity);
+        if (XrayConfigHelper.isScenarioReportEvidenceEnabled() && xrayTestAnnotation.scenarioReport()) {
+            // Get rendered template
+            Writer renderedTemplate = scenarioReportCreator.getRenderedTemplate(collection, scenarioLog);
+            String filename = "scenario_" + scenarioLog.getScenarioName() + ".html";
+            xrayTestEntity.addEvidence(XrayEvidenceItemEntity.fromString(renderedTemplate.toString(), filename));
         }
 
         // add scenario image evidence
-        if (xrayTestAnnotation.screenshots()) {
-            addScenarioImageEvidence(scenarioLog, xrayTestEntity);
+        if (XrayConfigHelper.isScenarioImageEvidenceEnabled() && xrayTestAnnotation.screenshots()) {
+            for (String filepath : scenarioLog.getScreenshotPaths()) {
+                xrayTestEntity.addEvidence(XrayEvidenceItemEntity.fromFile(filepath));
+            }
         }
 
         xrayTestEntity.setStatus(scenarioLog.getStatus());
@@ -227,49 +209,22 @@ public class XrayJsonImportBuilder {
         return xrayTestEntity;
     }
 
-    /**
-     * Build a step entity from a step log message
-     *
-     * @param stepLog step log message
-     * @return Xray step entity
-     */
     private XrayManualTestStepResultEntity buildXrayManualTestStepResultEntity(StepInformationLogMessage stepLog) {
-        // Create Step Log entity
         XrayManualTestStepResultEntity xrayTestStepEntity = new XrayManualTestStepResultEntity();
-
-        // Set Step comment
+        xrayTestStepEntity.setStatus(stepLog.getStatus());
         if (stepLog.getStep() != null) {
             xrayTestStepEntity.setComment(stepLog.getStep().getName());
         }
-        xrayTestStepEntity.setStatus(stepLog.getStatus());
-        return xrayTestStepEntity;
-    }
-
-    /**
-     * Add an HTML Report to the Xray Test Entity
-     *
-     * @param collection            Test Suite Logs
-     * @param scenarioReportCreator Object that can build a scenario report
-     * @param scenarioLog           Scenario Logs
-     * @param xrayTestEntity        Xray Test Entity
-     */
-    protected void addScenarioReport(TestSuiteLogCollection collection, ScenarioReportCreator scenarioReportCreator, TestScenarioLogCollection scenarioLog, XrayTestEntity xrayTestEntity) {
-        if (XrayConfigHelper.isScenarioReportEvidenceEnabled()) {
-            // Get rendered template
-            Writer renderedTemplate = scenarioReportCreator.getRenderedTemplate(
-                    collection, scenarioLog
-            );
-
-            // Create evidence entity for report
-            XrayEvidenceItemEntity xrayReportEvidence = new XrayEvidenceItemEntity()
-                    .setFilename("scenario_" + scenarioLog.getScenarioName() + ".html")
-                    .setContentType("text/html")
-                    .setData(Base64Helper.encode(renderedTemplate.toString()));
-
-            // Add report evidence to upload
-            xrayTestEntity
-                    .addEvidence(xrayReportEvidence);
+        if (stepLog.getResult() != null) {
+            xrayTestStepEntity.setActualResult(stepLog.getResult().toString());
         }
+        if (stepLog.getScreenshotBefore() != null && !stepLog.getScreenshotBefore().isBlank()) {
+            xrayTestStepEntity.addEvidenceIfPresent(XrayEvidenceItemEntity.fromFile(stepLog.getScreenshotBefore()));
+        }
+        if (stepLog.getScreenshotAfter() != null && !stepLog.getScreenshotAfter().isBlank()) {
+            xrayTestStepEntity.addEvidenceIfPresent(XrayEvidenceItemEntity.fromFile(stepLog.getScreenshotAfter()));
+        }
+        return xrayTestStepEntity;
     }
 
     /**
@@ -299,37 +254,6 @@ public class XrayJsonImportBuilder {
                 .setStart(null) // TODO
                 .setFinish(null) // TODO
                 .setComment(scenarioLog.getDescription());
-    }
-
-    /**
-     * Add evidence to a xray test entity if available and enabled in the configuration
-     *
-     * @param scenarioLog    Scenario Log object
-     * @param xrayTestEntity Xray Test Entity object
-     */
-    protected void addScenarioImageEvidence(TestScenarioLogCollection scenarioLog, XrayTestEntity xrayTestEntity) {
-        if (XrayConfigHelper.isScenarioImageEvidenceEnabled()) {
-            // Iterate over scenario screenshot paths
-            for (String filepath : scenarioLog.getScreenshotPaths()) {
-                try {
-                    // Create image evidence entity
-                    XrayEvidenceItemEntity xrayEvidenceEntity = new XrayEvidenceItemEntity()
-                            .setFilename(Paths.get(filepath).getFileName().toString())
-                            .setContentType("image/png")
-                            .setData(Base64Helper.encodeFileContent(filepath));
-
-                    // Add evidence entity to upload DTO
-                    xrayTestEntity
-                            .addEvidence(xrayEvidenceEntity);
-                } catch (IOException e) {
-                    // Create error entity
-                    EvidenceUploadError error = new EvidenceUploadError(e)
-                            .setFilepath(filepath);
-                    ErrorLogCollection errors = ErrorLogCollection.getInstance();
-                    errors.addErrorLog(error);
-                }
-            }
-        }
     }
 
     private static String truncateParameterName(String parameterName) {

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/entity/XrayEvidenceItemEntity.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/entity/XrayEvidenceItemEntity.java
@@ -1,5 +1,14 @@
 package de.qytera.qtaf.xray.entity;
 
+import de.qytera.qtaf.core.log.model.error.ErrorLogCollection;
+import de.qytera.qtaf.core.util.Base64Helper;
+import de.qytera.qtaf.xray.error.EvidenceUploadError;
+
+import javax.activation.FileTypeMap;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
 /**
  * Xray Evidence Entity
  */
@@ -18,6 +27,61 @@ public class XrayEvidenceItemEntity {
      * MIME type of file
      */
     private String contentType;
+
+
+    /**
+     * Transforms the provided file into an evidence entity.
+     *
+     * @param filepath the path to the file
+     * @return a corresponding evidence entity
+     */
+    public static XrayEvidenceItemEntity fromFile(String filepath) {
+        return fromFile(filepath, null);
+    }
+
+    /**
+     * Transforms the provided file into an evidence entity. If {@code evidenceName} is {@code null}, the name of the
+     * provided file will be used as name. Otherwise, the provided name will be used.
+     *
+     * @param filepath     the path to the file
+     * @param evidenceName an optional name to assign to the evidence
+     * @return a corresponding evidence entity
+     */
+    public static XrayEvidenceItemEntity fromFile(String filepath, String evidenceName) {
+        try {
+            Path path = Paths.get(filepath);
+            String mimeType = FileTypeMap.getDefaultFileTypeMap().getContentType(path.toFile());
+            return new XrayEvidenceItemEntity()
+                    .setFilename(evidenceName == null ? path.getFileName().toString() : evidenceName)
+                    .setContentType(mimeType)
+                    .setData(Base64Helper.encodeFileContent(path.toAbsolutePath().toString()));
+        } catch (IOException | NullPointerException e) {
+            EvidenceUploadError error = new EvidenceUploadError(e)
+                    .setFilepath(filepath);
+            ErrorLogCollection.getInstance().addErrorLog(error);
+        }
+        return null;
+    }
+
+    /**
+     * Transforms the provided {@code String} data into an evidence entity.
+     *
+     * @param data         the data to convert into evidence
+     * @param evidenceName the name to assign to the evidence
+     * @return a corresponding evidence entity
+     */
+    public static XrayEvidenceItemEntity fromString(String data, String evidenceName) {
+        try {
+            String mimeType = FileTypeMap.getDefaultFileTypeMap().getContentType(data);
+            return new XrayEvidenceItemEntity()
+                    .setFilename(evidenceName)
+                    .setContentType(mimeType)
+                    .setData(Base64Helper.encode(data));
+        } catch (NullPointerException e) {
+            ErrorLogCollection.getInstance().addErrorLog(new EvidenceUploadError(e));
+        }
+        return null;
+    }
 
     /**
      * Get data

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/entity/XrayManualTestStepResultEntity.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/entity/XrayManualTestStepResultEntity.java
@@ -98,6 +98,20 @@ public class XrayManualTestStepResultEntity {
     }
 
     /**
+     * Add an evidence item to the list of step evidences. If {@code evidence} is {@code null}, the current list of
+     * evidences remains unchanged.
+     *
+     * @param evidence the evidence to add
+     * @return this
+     */
+    public XrayManualTestStepResultEntity addEvidenceIfPresent(XrayEvidenceItemEntity evidence) {
+        if (evidence != null) {
+            this.evidences.add(evidence);
+        }
+        return this;
+    }
+
+    /**
      * Get defects
      *
      * @return defects Defects

--- a/qtaf-xray-plugin/src/test/java/de/qytera/qtaf/xray/builder/XrayJsonImportBuilderTest.java
+++ b/qtaf-xray-plugin/src/test/java/de/qytera/qtaf/xray/builder/XrayJsonImportBuilderTest.java
@@ -11,9 +11,11 @@ import de.qytera.qtaf.xray.annotation.XrayTest;
 import de.qytera.qtaf.xray.config.XrayConfigHelper;
 import de.qytera.qtaf.xray.config.XrayStatusHelper;
 import de.qytera.qtaf.xray.dto.request.XrayImportRequestDto;
+import de.qytera.qtaf.xray.entity.XrayManualTestStepResultEntity;
 import de.qytera.qtaf.xray.entity.XrayTestIterationParameterEntity;
 import de.qytera.qtaf.xray.entity.XrayTestIterationResultEntity;
 import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.lang.annotation.Annotation;
@@ -34,12 +36,12 @@ public class XrayJsonImportBuilderTest {
 
         @Override
         public boolean scenarioReport() {
-            return false;
+            return true;
         }
 
         @Override
         public boolean screenshots() {
-            return false;
+            return true;
         }
 
         @Override
@@ -48,50 +50,25 @@ public class XrayJsonImportBuilderTest {
         }
     };
 
-    private static TestScenarioLogCollection scenarioWithId(String id) {
-        TestScenarioLogCollection scenarioCollection = TestScenarioLogCollection.createTestScenarioLogCollection("feature-1", "scenario-1", id, "debug-scenario");
+    private static TestScenarioLogCollection scenario(int scenarioIteration, String featureName) {
+        TestScenarioLogCollection scenarioCollection = TestScenarioLogCollection.createTestScenarioLogCollection(
+                featureName,
+                "SomeClass.doesSomething",
+                String.valueOf(scenarioIteration),
+                "a test scenario"
+        );
         scenarioCollection.setStart(Date.from(Instant.now().minusSeconds(3600)));
         scenarioCollection.setEnd(Date.from(Instant.now()));
         scenarioCollection.setAnnotations(new Annotation[]{ANNOTATION});
+        // Add scenario to its corresponding feature collection.
+        TestFeatureLogCollection featureCollection = TestFeatureLogCollection.createFeatureLogCollectionIfNotExists(
+                featureName,
+                "a test feature"
+        );
+        featureCollection.addScenarioLogCollection(scenarioCollection);
+        // Add feature to suite collection.
+        TestSuiteLogCollection.getInstance().addTestClassLogCollection(featureCollection);
         return scenarioCollection;
-    }
-
-    @Test
-    public void testLongParameterValueTruncation() {
-        ConfigMap configMap = QtafFactory.getConfiguration();
-        configMap.setInt(XrayConfigHelper.RESULTS_ITERATIONS_PARAMETERS_MAX_LENGTH_VALUE, 3);
-
-        TestFeatureLogCollection featureCollection = TestFeatureLogCollection.createFeatureLogCollectionIfNotExists("feature-1", "feature-xray");
-        TestSuiteLogCollection suiteCollection = TestSuiteLogCollection.getInstance();
-        suiteCollection.addTestClassLogCollection(featureCollection);
-
-        TestScenarioLogCollection scenarioCollection = scenarioWithId("0");
-        scenarioCollection.addParameters(new String[]{
-                "a",
-                "abcd",
-                "abcdefghijklmnop",
-                "abcdefghijklmnopqrstuvwxyz01234567891011121314151617181920212223"
-        });
-        featureCollection.addScenarioLogCollection(scenarioCollection);
-
-        scenarioCollection = scenarioWithId("1");
-        scenarioCollection.addParameters(new String[]{
-                "ab",
-                "abcdefghi",
-                "abcdefghijklmnopqrstuvwxyz012345"
-        });
-        featureCollection.addScenarioLogCollection(scenarioCollection);
-
-        XrayImportRequestDto dto = new XrayJsonImportBuilder().buildFromTestSuiteLogs(suiteCollection);
-        List<XrayTestIterationResultEntity> iterations = dto.getTests().get(0).getIterations();
-        Assert.assertEquals(
-                iterations.get(0).getParameters().stream().map(XrayTestIterationParameterEntity::getValue).collect(Collectors.toList()),
-                Arrays.asList("a", "abc", "abc", "abc")
-        );
-        Assert.assertEquals(
-                iterations.get(1).getParameters().stream().map(XrayTestIterationParameterEntity::getValue).collect(Collectors.toList()),
-                Arrays.asList("ab", "abc", "abc")
-        );
     }
 
     private static StepInformationLogMessage successfulStep(String methodName) {
@@ -106,43 +83,161 @@ public class XrayJsonImportBuilderTest {
         return message;
     }
 
+    private static StepInformationLogMessage failingStep(
+            String methodName,
+            String screenshotPathBefore
+    ) {
+        StepInformationLogMessage message = new StepInformationLogMessage(methodName, "?");
+        message.setStatus(StepInformationLogMessage.Status.ERROR);
+        message.setScreenshotBefore(screenshotPathBefore);
+        return message;
+    }
+
+    private static StepInformationLogMessage failingStep(
+            String methodName,
+            String screenshotPathBefore,
+            String screenshotPathAfter
+    ) {
+        StepInformationLogMessage message = new StepInformationLogMessage(methodName, "?");
+        message.setStatus(StepInformationLogMessage.Status.ERROR);
+        message.setScreenshotBefore(screenshotPathBefore);
+        message.setScreenshotAfter(screenshotPathAfter);
+        return message;
+    }
+
+    @BeforeMethod
+    public void clearSuite() {
+        TestSuiteLogCollection.getInstance().clear();
+        TestFeatureLogCollection.clearIndex();
+        TestScenarioLogCollection.clearIndex();
+    }
+
+    @Test
+    public void testLongParameterValueTruncation() {
+        ConfigMap configMap = QtafFactory.getConfiguration();
+        configMap.setInt(XrayConfigHelper.RESULTS_ITERATIONS_PARAMETERS_MAX_LENGTH_VALUE, 3);
+
+        TestScenarioLogCollection scenarioCollection = scenario(0, "feature-1");
+        scenarioCollection.addParameters(new String[]{
+                "a",
+                "abcd",
+                "abcdefghijklmnop",
+                "abcdefghijklmnopqrstuvwxyz01234567891011121314151617181920212223"
+        });
+
+        scenarioCollection = scenario(1, "feature-1");
+        scenarioCollection.addParameters(new String[]{
+                "ab",
+                "abcdefghi",
+                "abcdefghijklmnopqrstuvwxyz012345"
+        });
+
+        XrayImportRequestDto dto = new XrayJsonImportBuilder().buildFromTestSuiteLogs(TestSuiteLogCollection.getInstance());
+        List<XrayTestIterationResultEntity> iterations = dto.getTests().get(0).getIterations();
+        Assert.assertEquals(
+                iterations.get(0).getParameters().stream().map(XrayTestIterationParameterEntity::getValue).collect(Collectors.toList()),
+                Arrays.asList("a", "abc", "abc", "abc")
+        );
+        Assert.assertEquals(
+                iterations.get(1).getParameters().stream().map(XrayTestIterationParameterEntity::getValue).collect(Collectors.toList()),
+                Arrays.asList("ab", "abc", "abc")
+        );
+    }
+
     @Test
     public void testIterationStatus() {
 
-        TestFeatureLogCollection featureCollection = TestFeatureLogCollection.createFeatureLogCollectionIfNotExists("feature-1", "feature-xray");
-        TestSuiteLogCollection suiteCollection = TestSuiteLogCollection.getInstance();
-        suiteCollection.addTestClassLogCollection(featureCollection);
-
         // Iteration with no failing step and an assumed successful assertion.
-        TestScenarioLogCollection scenarioCollection = scenarioWithId("0");
+        TestScenarioLogCollection scenarioCollection = scenario(0, "feature-1");
         scenarioCollection.addLogMessage(successfulStep("enterUsername"));
         scenarioCollection.addLogMessage(successfulStep("enterPassword"));
         scenarioCollection.addLogMessage(successfulStep("clickLogin"));
         scenarioCollection.setStatus(TestScenarioLogCollection.Status.SUCCESS);
-        featureCollection.addScenarioLogCollection(scenarioCollection);
 
         // Iteration with no failing step and an assumed failed assertion.
-        scenarioCollection = scenarioWithId("1");
+        scenarioCollection = scenario(1, "feature-1");
         scenarioCollection.addLogMessage(successfulStep("enterUsername"));
         scenarioCollection.addLogMessage(successfulStep("enterPassword"));
         scenarioCollection.addLogMessage(successfulStep("clickLogin"));
         scenarioCollection.setStatus(TestScenarioLogCollection.Status.FAILURE);
-        featureCollection.addScenarioLogCollection(scenarioCollection);
 
         // Iteration with a failing step.
-        scenarioCollection = scenarioWithId("2");
+        scenarioCollection = scenario(2, "feature-1");
         scenarioCollection.addLogMessage(successfulStep("enterUsername"));
         scenarioCollection.addLogMessage(successfulStep("enterPassword"));
         scenarioCollection.addLogMessage(failingStep("clickLogin"));
         scenarioCollection.setStatus(TestScenarioLogCollection.Status.FAILURE);
-        featureCollection.addScenarioLogCollection(scenarioCollection);
 
         ConfigurationFactory.getInstance().setString(XrayConfigHelper.XRAY_SERVICE_SELECTOR, "server");
-        XrayImportRequestDto dto = new XrayJsonImportBuilder().buildFromTestSuiteLogs(suiteCollection);
+        XrayImportRequestDto dto = new XrayJsonImportBuilder().buildFromTestSuiteLogs(TestSuiteLogCollection.getInstance());
         List<XrayTestIterationResultEntity> iterations = dto.getTests().get(0).getIterations();
         Assert.assertEquals(iterations.get(0).getStatus(), XrayStatusHelper.statusToText(TestScenarioLogCollection.Status.SUCCESS));
         Assert.assertEquals(iterations.get(1).getStatus(), XrayStatusHelper.statusToText(TestScenarioLogCollection.Status.FAILURE));
         Assert.assertEquals(iterations.get(2).getStatus(), XrayStatusHelper.statusToText(TestScenarioLogCollection.Status.FAILURE));
+    }
+
+    @Test
+    public void testSingleRunScreenshotEvidence() {
+
+        // Iteration with no failing step and an assumed successful assertion.
+        TestScenarioLogCollection scenarioCollection = scenario(0, "feature-1");
+        scenarioCollection.addLogMessage(successfulStep("enterUsername"));
+        scenarioCollection.addLogMessage(successfulStep("enterPassword"));
+        scenarioCollection.addLogMessage(failingStep(
+                "clickLogout",
+                "src/test/resources/images/qytera.png",
+                "src/test/resources/images/turtle.png")
+        );
+        scenarioCollection.setStatus(TestScenarioLogCollection.Status.FAILURE);
+
+        ConfigurationFactory.getInstance().setString(XrayConfigHelper.XRAY_SERVICE_SELECTOR, "server");
+        XrayImportRequestDto dto = new XrayJsonImportBuilder().buildFromTestSuiteLogs(TestSuiteLogCollection.getInstance());
+        List<XrayManualTestStepResultEntity> steps = dto.getTests().get(0).getSteps();
+        Assert.assertTrue(steps.get(0).getEvidences().isEmpty());
+        Assert.assertTrue(steps.get(1).getEvidences().isEmpty());
+        Assert.assertEquals(steps.get(2).getEvidences().size(), 2);
+        Assert.assertEquals(steps.get(2).getEvidences().get(0).getContentType(), "image/png");
+        Assert.assertEquals(steps.get(2).getEvidences().get(0).getFilename(), "qytera.png");
+        Assert.assertEquals(steps.get(2).getEvidences().get(1).getContentType(), "image/png");
+        Assert.assertEquals(steps.get(2).getEvidences().get(1).getFilename(), "turtle.png");
+    }
+
+    @Test
+    public void testIterationsScreenshotEvidence() {
+
+        // Iteration with no failing step and an assumed successful assertion.
+        TestScenarioLogCollection scenarioCollection = scenario(0, "feature-1");
+        scenarioCollection.addLogMessage(successfulStep("enterUsername"));
+        scenarioCollection.addLogMessage(successfulStep("enterPassword"));
+        scenarioCollection.addLogMessage(failingStep(
+                "clickLogout",
+                "",
+                "src/test/resources/images/turtle.png")
+        );
+        scenarioCollection.setStatus(TestScenarioLogCollection.Status.FAILURE);
+
+        scenarioCollection = scenario(1, "feature-1");
+        scenarioCollection.addLogMessage(successfulStep("enterUsername"));
+        scenarioCollection.addLogMessage(failingStep(
+                "clickLogout",
+                "src/test/resources/images/turtle.png")
+        );
+        scenarioCollection.setStatus(TestScenarioLogCollection.Status.FAILURE);
+
+        ConfigurationFactory.getInstance().setString(XrayConfigHelper.XRAY_SERVICE_SELECTOR, "server");
+        XrayImportRequestDto dto = new XrayJsonImportBuilder().buildFromTestSuiteLogs(TestSuiteLogCollection.getInstance());
+        List<XrayTestIterationResultEntity> iterations = dto.getTests().get(0).getIterations();
+
+        Assert.assertTrue(iterations.get(0).getSteps().get(0).getEvidences().isEmpty());
+        Assert.assertTrue(iterations.get(0).getSteps().get(1).getEvidences().isEmpty());
+        Assert.assertEquals(iterations.get(0).getSteps().get(2).getEvidences().size(), 1);
+        Assert.assertEquals(iterations.get(0).getSteps().get(2).getEvidences().get(0).getContentType(), "image/png");
+        Assert.assertEquals(iterations.get(0).getSteps().get(2).getEvidences().get(0).getFilename(), "turtle.png");
+
+        Assert.assertTrue(iterations.get(1).getSteps().get(0).getEvidences().isEmpty());
+        Assert.assertEquals(iterations.get(1).getSteps().get(1).getEvidences().size(), 1);
+        Assert.assertEquals(iterations.get(1).getSteps().get(1).getEvidences().get(0).getContentType(), "image/png");
+        Assert.assertEquals(iterations.get(1).getSteps().get(1).getEvidences().get(0).getFilename(), "turtle.png");
     }
 
 }


### PR DESCRIPTION
This PR attaches step screenshots as evidence to steps inside test *iterations*. Currently, step screenshots are only being attached to tests without iterations.