### PR TITLE
Fix missing file detector for remote web drivers

### DIFF
--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AbstractAndroidDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AbstractAndroidDriver.java
@@ -2,6 +2,7 @@ package de.qytera.qtaf.core.selenium;
 
 import io.appium.java_client.android.AndroidDriver;
 import io.appium.java_client.remote.MobileCapabilityType;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import java.net.MalformedURLException;
@@ -13,20 +14,34 @@ import java.net.URL;
 public abstract class AbstractAndroidDriver extends AbstractDriver {
 
     /**
+     * Creates a new android driver.
+     */
+    protected AbstractAndroidDriver() {
+        super(false);
+    }
+
+    /**
      * Get driver capabilities
      *
      * @return driver capabilities
      */
     protected DesiredCapabilities getCapabilities() {
         DesiredCapabilities dc = new DesiredCapabilities();
-
-        logInfo("[DesiredCapabilities] " + MobileCapabilityType.DEVICE_NAME + ": " + configMap.getString("appium.capabilities.deviceName"));
-        dc.setCapability(MobileCapabilityType.DEVICE_NAME, configMap.getString("appium.capabilities.deviceName"));
-
-        logInfo("[DesiredCapabilities] " + MobileCapabilityType.PLATFORM_NAME + ": " + configMap.getString("appium.capabilities.platformName"));
-        dc.setCapability(MobileCapabilityType.PLATFORM_NAME, configMap.getString("appium.capabilities.platformName"));
-
+        logDesiredCapability(MobileCapabilityType.DEVICE_NAME, CONFIG.getString("appium.capabilities.deviceName"));
+        logDesiredCapability(CapabilityType.PLATFORM_NAME, CONFIG.getString("appium.capabilities.platformName"));
+        dc.setCapability(MobileCapabilityType.DEVICE_NAME, CONFIG.getString("appium.capabilities.deviceName"));
+        dc.setCapability(CapabilityType.PLATFORM_NAME, CONFIG.getString("appium.capabilities.platformName"));
         return dc;
+    }
+
+    /**
+     * Creates a log message describing the desired capability and its desired value.
+     *
+     * @param capability the desired capability
+     * @param value      the desired value
+     */
+    protected void logDesiredCapability(String capability, String value) {
+        logInfo(String.format("[DesiredCapabilities] %s: %s", capability, value));
     }
 
     /**
@@ -37,9 +52,8 @@ public abstract class AbstractAndroidDriver extends AbstractDriver {
      */
     protected DesiredCapabilities getDesiredCapabilitiesBrowser(String browserName) {
         DesiredCapabilities dc = getCapabilities();
-
-        logInfo("[DesiredCapabilities] " + MobileCapabilityType.BROWSER_NAME + ": " + browserName);
-        dc.setCapability(MobileCapabilityType.BROWSER_NAME, browserName);
+        logDesiredCapability(CapabilityType.BROWSER_NAME, browserName);
+        dc.setCapability(CapabilityType.BROWSER_NAME, browserName);
 
         return dc;
     }
@@ -52,12 +66,8 @@ public abstract class AbstractAndroidDriver extends AbstractDriver {
      */
     protected AndroidDriver getAndroidDriver(DesiredCapabilities dc) {
         try {
-            logInfo("[Android Driver] " + "URL" + ": " + configMap.getString("appium.driverSettings.url"));
-
-            AndroidDriver androidDriver = new AndroidDriver(
-                    new URL(configMap.getString("appium.driverSettings.url")), dc);
-
-            return androidDriver;
+            logInfo("[Android Driver] " + "URL" + ": " + CONFIG.getString("appium.driverSettings.url"));
+            return new AndroidDriver(new URL(CONFIG.getString("appium.driverSettings.url")), dc);
         } catch (MalformedURLException e) {
             e.printStackTrace();
             return null;

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AbstractDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AbstractDriver.java
@@ -7,6 +7,8 @@ import de.qytera.qtaf.core.selenium.helper.SeleniumDriverConfigHelper;
 import io.github.bonigarcia.wdm.WebDriverManager;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 /**
  * Abstract driver class that all driver classes inherit from
@@ -16,12 +18,26 @@ public abstract class AbstractDriver {
     /**
      * Configuration
      */
-    protected ConfigMap configMap = QtafFactory.getConfiguration();
+    protected static final ConfigMap CONFIG = QtafFactory.getConfiguration();
 
     /**
      * Logger
      */
-    protected static Logger logger = QtafFactory.getLogger();
+    protected static final Logger LOGGER = QtafFactory.getLogger();
+
+    /**
+     * Whether the driver runs on a different machine, e.g. when using chrome-remote or firefox-remote.
+     */
+    private final boolean isRunningRemotely;
+
+    /**
+     * Creates a new driver.
+     *
+     * @param isRunningRemotely whether the driver runs on a different machine
+     */
+    protected AbstractDriver(boolean isRunningRemotely) {
+        this.isRunningRemotely = isRunningRemotely;
+    }
 
     /**
      * Get Driver name
@@ -35,7 +51,16 @@ public abstract class AbstractDriver {
      *
      * @return selenium web driver object
      */
-    public abstract WebDriver getDriver();
+    public final WebDriver getDriver() {
+        WebDriver driver = getDriverInstance();
+        if (isRunningRemotely) {
+            // See: https://www.selenium.dev/documentation/webdriver/drivers/remote_webdriver/#local-file-detector
+            ((RemoteWebDriver) driver).setFileDetector(new LocalFileDetector());
+        }
+        return driver;
+    }
+
+    protected abstract WebDriver getDriverInstance();
 
     /**
      * Log an info message
@@ -43,7 +68,7 @@ public abstract class AbstractDriver {
      * @param message Log message
      */
     static void logInfo(String message) {
-        logger.info("[DriverFactory] " + message);
+        LOGGER.info("[DriverFactory] " + message);
     }
 
     /**

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AndroidDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AndroidDriver.java
@@ -2,6 +2,7 @@ package de.qytera.qtaf.core.selenium;
 
 import io.appium.java_client.remote.MobileCapabilityType;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 /**
@@ -14,10 +15,8 @@ public class AndroidDriver extends AbstractAndroidDriver {
     }
 
     @Override
-    public WebDriver getDriver() {
-        DesiredCapabilities dc = getCapabilities();
-        WebDriver driver = getAndroidDriver(dc);
-        return driver;
+    public WebDriver getDriverInstance() {
+        return getAndroidDriver(getCapabilities());
     }
 
     /**
@@ -25,21 +24,17 @@ public class AndroidDriver extends AbstractAndroidDriver {
      *
      * @return capabilities
      */
+    @Override
     protected DesiredCapabilities getCapabilities() {
-        DesiredCapabilities dc = getCapabilities();
-
-        logInfo("[DesiredCapabilities] " + MobileCapabilityType.UDID + ": " + configMap.getString("appium.capabilities.udid"));
-        dc.setCapability(MobileCapabilityType.UDID, configMap.getString("appium.capabilities.udid"));
-
-        logInfo("[DesiredCapabilities] " + MobileCapabilityType.VERSION + ": " + configMap.getString("appium.capabilities.androidVersion"));
-        dc.setCapability(MobileCapabilityType.VERSION, configMap.getString("appium.capabilities.androidVersion"));
-
-        logInfo("[DesiredCapabilities] " + "appPackage" + ": " + configMap.getString("appium.capabilities.appPackage"));
-        dc.setCapability("appPackage", configMap.getString("appium.capabilities.appPackage"));
-
-        logInfo("[DesiredCapabilities] " + "appActivity" + ": " + configMap.getString("appium.capabilities.appActivity"));
-        dc.setCapability("appActivity", configMap.getString("appium.capabilities.appActivity"));
-
+        DesiredCapabilities dc = super.getCapabilities();
+        logDesiredCapability(MobileCapabilityType.UDID, CONFIG.getString("appium.capabilities.udid"));
+        logDesiredCapability(CapabilityType.BROWSER_VERSION, CONFIG.getString("appium.capabilities.androidVersion"));
+        logDesiredCapability("appPackage", CONFIG.getString("appium.capabilities.appPackage"));
+        logDesiredCapability("appActivity", CONFIG.getString("appium.capabilities.appActivity"));
+        dc.setCapability(MobileCapabilityType.UDID, CONFIG.getString("appium.capabilities.udid"));
+        dc.setCapability(CapabilityType.BROWSER_VERSION, CONFIG.getString("appium.capabilities.androidVersion"));
+        dc.setCapability("appPackage", CONFIG.getString("appium.capabilities.appPackage"));
+        dc.setCapability("appActivity", CONFIG.getString("appium.capabilities.appActivity"));
         return dc;
     }
 

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/ChromeAndroidDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/ChromeAndroidDriver.java
@@ -12,7 +12,7 @@ public class ChromeAndroidDriver extends AbstractAndroidDriver {
     }
 
     @Override
-    public WebDriver getDriver() {
+    public WebDriver getDriverInstance() {
         return getAndroidDriver(getDesiredCapabilitiesBrowser("Chrome"));
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/ChromeDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/ChromeDriver.java
@@ -8,13 +8,21 @@ import org.openqa.selenium.chrome.ChromeOptions;
  * This class is responsible for managing the selenium chrome driver
  */
 public class ChromeDriver extends AbstractDriver {
+
+    /**
+     * Creates a new chrome driver.
+     */
+    public ChromeDriver() {
+        super(false);
+    }
+
     @Override
     public String getName() {
         return "chrome";
     }
 
     @Override
-    public WebDriver getDriver() {
+    public WebDriver getDriverInstance() {
         WebDriverManager webDriverManager = WebDriverManager.chromedriver();
         initWebDriverManager(webDriverManager);
         return new org.openqa.selenium.chrome.ChromeDriver(getCapabilities());

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/ChromeRemoteDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/ChromeRemoteDriver.java
@@ -11,13 +11,20 @@ import org.openqa.selenium.remote.RemoteWebDriver;
  */
 public class ChromeRemoteDriver extends AbstractDriver {
 
+    /**
+     * Creates a new chrome-remote driver.
+     */
+    public ChromeRemoteDriver() {
+        super(true);
+    }
+
     @Override
     public String getName() {
         return "chrome-remote";
     }
 
     @Override
-    public WebDriver getDriver() {
+    public WebDriver getDriverInstance() {
         return new RemoteWebDriver(SeleniumDriverConfigHelper.getRemoteUrl(), getCapabilities());
     }
 

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/DriverFactory.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/DriverFactory.java
@@ -10,6 +10,8 @@ import de.qytera.qtaf.core.log.model.error.ErrorLogCollection;
 import de.qytera.qtaf.core.reflection.ClassLoader;
 import de.qytera.qtaf.core.selenium.helper.SeleniumDriverConfigHelper;
 import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.remote.LocalFileDetector;
+import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.util.concurrent.TimeUnit;
 
@@ -94,6 +96,10 @@ public class DriverFactory {
 
         // Initialize driver
         if (driver != null) {
+            // See: https://www.selenium.dev/documentation/webdriver/drivers/remote_webdriver/#local-file-detector
+            if (driver instanceof RemoteWebDriver remoteDriver) {
+                remoteDriver.setFileDetector(new LocalFileDetector());
+            }
             logInfo("Driver initialized: " + driverName);
             QtafEvents.afterDriverInitialization.onNext(d);
         } else {

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/DriverFactory.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/DriverFactory.java
@@ -9,15 +9,16 @@ import de.qytera.qtaf.core.log.model.error.DriverInitializationError;
 import de.qytera.qtaf.core.log.model.error.ErrorLogCollection;
 import de.qytera.qtaf.core.reflection.ClassLoader;
 import de.qytera.qtaf.core.selenium.helper.SeleniumDriverConfigHelper;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 import org.openqa.selenium.WebDriver;
-import org.openqa.selenium.remote.LocalFileDetector;
-import org.openqa.selenium.remote.RemoteWebDriver;
 
 import java.util.concurrent.TimeUnit;
 
 /**
  * Driver factory class
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class DriverFactory {
     /**
      * Selenium Web Driver object
@@ -37,7 +38,7 @@ public class DriverFactory {
     /**
      * Logger
      */
-    private static Logger logger = QtafFactory.getLogger();
+    private static final Logger LOGGER = QtafFactory.getLogger();
 
     /**
      * Get default web driver instance. The default driver name is fetched from the QTAF configuration.
@@ -79,7 +80,7 @@ public class DriverFactory {
                     break;
                 }
             }
-        } catch (Throwable e) {
+        } catch (Exception e) {
             // Add error log
             errorLogCollection.addErrorLog(new DriverInitializationError(e));
 
@@ -96,10 +97,6 @@ public class DriverFactory {
 
         // Initialize driver
         if (driver != null) {
-            // See: https://www.selenium.dev/documentation/webdriver/drivers/remote_webdriver/#local-file-detector
-            if (driver instanceof RemoteWebDriver remoteDriver) {
-                remoteDriver.setFileDetector(new LocalFileDetector());
-            }
             logInfo("Driver initialized: " + driverName);
             QtafEvents.afterDriverInitialization.onNext(d);
         } else {
@@ -184,7 +181,7 @@ public class DriverFactory {
      * @param message Log message
      */
     private static void logInfo(String message) {
-        logger.info("[DriverFactory] " + message);
+        LOGGER.info("[DriverFactory] " + message);
     }
 
     /**
@@ -193,7 +190,7 @@ public class DriverFactory {
      * @param message Log message
      */
     private static void logError(String message) {
-        logger.error("[DriverFactory] " + message);
+        LOGGER.error("[DriverFactory] " + message);
     }
 
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/EdgeDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/EdgeDriver.java
@@ -8,13 +8,21 @@ import org.openqa.selenium.edge.EdgeOptions;
  * This class is responsible for connecting to a local edge browser
  */
 public class EdgeDriver extends AbstractDriver {
+
+    /**
+     * Creates a new edge driver.
+     */
+    public EdgeDriver() {
+        super(false);
+    }
+
     @Override
     public String getName() {
         return "edge";
     }
 
     @Override
-    public WebDriver getDriver() {
+    public WebDriver getDriverInstance() {
         WebDriverManager webDriverManager = WebDriverManager.edgedriver();
         initWebDriverManager(webDriverManager);
         return new org.openqa.selenium.edge.EdgeDriver(getCapabilities());
@@ -24,7 +32,6 @@ public class EdgeDriver extends AbstractDriver {
     protected EdgeOptions getCapabilities() {
         // Make selenium use the selenium-http-jdk-client package
         System.setProperty("webdriver.http.factory", "jdk-http-client");
-        EdgeOptions options = new EdgeOptions();
-        return options;
+        return new EdgeOptions();
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/EdgeRemoteDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/EdgeRemoteDriver.java
@@ -11,13 +11,20 @@ import org.openqa.selenium.remote.RemoteWebDriver;
  */
 public class EdgeRemoteDriver extends AbstractDriver {
 
+    /**
+     * Creates a new edge-remote driver.
+     */
+    public EdgeRemoteDriver() {
+        super(false);
+    }
+
     @Override
     public String getName() {
         return "edge-remote";
     }
 
     @Override
-    public WebDriver getDriver() {
+    public WebDriver getDriverInstance() {
         return new RemoteWebDriver(SeleniumDriverConfigHelper.getRemoteUrl(), getCapabilities());
     }
 

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxAndroidDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxAndroidDriver.java
@@ -12,7 +12,7 @@ public class FirefoxAndroidDriver extends AbstractAndroidDriver {
     }
 
     @Override
-    public WebDriver getDriver() {
+    public WebDriver getDriverInstance() {
         return getAndroidDriver(getDesiredCapabilitiesBrowser("Firefox"));
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxDriver.java
@@ -8,13 +8,21 @@ import org.openqa.selenium.firefox.FirefoxOptions;
  * This class is responsible for connecting to a local firefox browser
  */
 public class FirefoxDriver extends AbstractDriver {
+
+    /**
+     * Creates a new firefox driver.
+     */
+    public FirefoxDriver() {
+        super(false);
+    }
+
     @Override
     public String getName() {
         return "firefox";
     }
 
     @Override
-    public WebDriver getDriver() {
+    public WebDriver getDriverInstance() {
         WebDriverManager webDriverManager = WebDriverManager.firefoxdriver();
         initWebDriverManager(webDriverManager);
         return new org.openqa.selenium.firefox.FirefoxDriver(getCapabilities());
@@ -24,7 +32,6 @@ public class FirefoxDriver extends AbstractDriver {
     protected FirefoxOptions getCapabilities() {
         // Make selenium use the selenium-http-jdk-client package
         System.setProperty("webdriver.http.factory", "jdk-http-client");
-        FirefoxOptions options = new FirefoxOptions();
-        return options;
+        return new FirefoxOptions();
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxRemoteDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxRemoteDriver.java
@@ -11,13 +11,20 @@ import org.openqa.selenium.remote.RemoteWebDriver;
  */
 public class FirefoxRemoteDriver extends AbstractDriver {
 
+    /**
+     * Creates a new firefox-remote driver.
+     */
+    public FirefoxRemoteDriver() {
+        super(true);
+    }
+
     @Override
     public String getName() {
         return "firefox-remote";
     }
 
     @Override
-    public WebDriver getDriver() {
+    public WebDriver getDriverInstance() {
         return new RemoteWebDriver(SeleniumDriverConfigHelper.getRemoteUrl(), getCapabilities());
     }
 

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/InternetExplorerDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/InternetExplorerDriver.java
@@ -8,13 +8,21 @@ import org.openqa.selenium.ie.InternetExplorerOptions;
  * This class is responsible for connecting to a local Internet Explorer browser
  */
 public class InternetExplorerDriver extends AbstractDriver {
+
+    /**
+     * Creates a new ie driver.
+     */
+    public InternetExplorerDriver() {
+        super(false);
+    }
+
     @Override
     public String getName() {
         return "ie";
     }
 
     @Override
-    public WebDriver getDriver() {
+    public WebDriver getDriverInstance() {
         WebDriverManager.iedriver().setup();
         return new org.openqa.selenium.ie.InternetExplorerDriver(this.getCapabilities());
     }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/SaucelabsDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/SaucelabsDriver.java
@@ -7,13 +7,21 @@ import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.RemoteWebDriver;
 
 public class SaucelabsDriver extends AbstractDriver {
+
+    /**
+     * Creates a new sauce driver.
+     */
+    public SaucelabsDriver() {
+        super(false);
+    }
+
     @Override
     public String getName() {
         return "sauce";
     }
 
     @Override
-    public WebDriver getDriver() {
+    public WebDriver getDriverInstance() {
         return new RemoteWebDriver(SeleniumDriverConfigHelper.getRemoteUrl(), getCapabilities());
     }
 

--- a/qtaf-core/src/test/java/de/qytera/qtaf/selenium/DriverTest.java
+++ b/qtaf-core/src/test/java/de/qytera/qtaf/selenium/DriverTest.java
@@ -12,11 +12,12 @@ import org.testng.annotations.Test;
 /**
  * Test instantiation of selenium drivers
  */
+@Test(groups = {"driver"})
 public class DriverTest {
     /**
      * Test if the driver gets cached
      */
-    @Test(groups = {"driver"})
+    @Test
     public void testDriverCache() {
         WebDriver webDriver1 = DriverFactory.getDriver("chrome");
         webDriver1.quit();
@@ -26,7 +27,7 @@ public class DriverTest {
         DriverFactory.clearDriver();
     }
 
-    @Test(groups = {"driver", "chrome"})
+    @Test(groups = {"chrome"})
     public void testChromeDriverInstantiation() {
         DriverFactory.clearDriver();
         WebDriver webDriver = DriverFactory.getDriver("chrome");
@@ -35,7 +36,7 @@ public class DriverTest {
         DriverFactory.clearDriver();
     }
 
-    @Test(groups = {"driver", "firefox"})
+    @Test(groups = {"firefox"})
     public void testFirefoxDriverInstantiation() {
         DriverFactory.clearDriver();
         WebDriver webDriver = DriverFactory.getDriver("firefox");
@@ -44,7 +45,7 @@ public class DriverTest {
         DriverFactory.clearDriver();
     }
 
-    @Test(groups = {"driver", "edge"})
+    @Test(groups = {"edge"})
     public void testEdgeDriverInstantiation() {
         DriverFactory.clearDriver();
         WebDriver webDriver = DriverFactory.getDriver("edge");
@@ -53,7 +54,7 @@ public class DriverTest {
         DriverFactory.clearDriver();
     }
 
-    @Test(groups = {"driver", "ie"})
+    @Test(groups = {"ie"})
     public void testIEDriverInstantiation() {
         DriverFactory.clearDriver();
         WebDriver webDriver = DriverFactory.getDriver("ie");


### PR DESCRIPTION
Fixes #81 by detecting instances of `RemoteWebDriver` and sets the file detector as described in https://www.selenium.dev/documentation/webdriver/drivers/remote_webdriver/#local-file-detector.