### PR TITLE
Replace driver constructors with `isRemoteDriver` method

### DIFF
--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AbstractAndroidDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AbstractAndroidDriver.java
@@ -14,13 +14,6 @@ import java.net.URL;
 public abstract class AbstractAndroidDriver extends AbstractDriver {
 
     /**
-     * Creates a new android driver.
-     */
-    protected AbstractAndroidDriver() {
-        super(false);
-    }
-
-    /**
      * Get driver capabilities
      *
      * @return driver capabilities

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AbstractDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AbstractDriver.java
@@ -26,20 +26,6 @@ public abstract class AbstractDriver {
     protected static final Logger LOGGER = QtafFactory.getLogger();
 
     /**
-     * Whether the driver runs on a different machine, e.g. when using chrome-remote or firefox-remote.
-     */
-    private final boolean isRunningRemotely;
-
-    /**
-     * Creates a new driver.
-     *
-     * @param isRunningRemotely whether the driver runs on a different machine
-     */
-    protected AbstractDriver(boolean isRunningRemotely) {
-        this.isRunningRemotely = isRunningRemotely;
-    }
-
-    /**
      * Get Driver name
      *
      * @return driver name
@@ -53,7 +39,7 @@ public abstract class AbstractDriver {
      */
     public final WebDriver getDriver() {
         WebDriver driver = getDriverInstance();
-        if (isRunningRemotely) {
+        if (isRemoteDriver()) {
             // See: https://www.selenium.dev/documentation/webdriver/drivers/remote_webdriver/#local-file-detector
             ((RemoteWebDriver) driver).setFileDetector(new LocalFileDetector());
         }
@@ -99,4 +85,11 @@ public abstract class AbstractDriver {
             webDriverManager.driverVersion(SeleniumDriverConfigHelper.getDriverVersion());
         }
     }
+
+    /**
+     * Whether the driver runs on a different machine, e.g. when using chrome-remote or firefox-remote.
+     *
+     * @return whether the driver runs on a different machine
+     */
+    protected abstract boolean isRemoteDriver();
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AndroidDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AndroidDriver.java
@@ -38,4 +38,9 @@ public class AndroidDriver extends AbstractAndroidDriver {
         return dc;
     }
 
+    @Override
+    protected boolean isRemoteDriver() {
+        return false;
+    }
+
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/ChromeAndroidDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/ChromeAndroidDriver.java
@@ -15,4 +15,9 @@ public class ChromeAndroidDriver extends AbstractAndroidDriver {
     public WebDriver getDriverInstance() {
         return getAndroidDriver(getDesiredCapabilitiesBrowser("Chrome"));
     }
+
+    @Override
+    protected boolean isRemoteDriver() {
+        return false;
+    }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/ChromeDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/ChromeDriver.java
@@ -9,13 +9,6 @@ import org.openqa.selenium.chrome.ChromeOptions;
  */
 public class ChromeDriver extends AbstractDriver {
 
-    /**
-     * Creates a new chrome driver.
-     */
-    public ChromeDriver() {
-        super(false);
-    }
-
     @Override
     public String getName() {
         return "chrome";
@@ -35,5 +28,10 @@ public class ChromeDriver extends AbstractDriver {
         ChromeOptions options = new ChromeOptions();
         options.setCapability("remote-allow-origins", "");
         return options;
+    }
+
+    @Override
+    protected boolean isRemoteDriver() {
+        return false;
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/ChromeRemoteDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/ChromeRemoteDriver.java
@@ -11,13 +11,6 @@ import org.openqa.selenium.remote.RemoteWebDriver;
  */
 public class ChromeRemoteDriver extends AbstractDriver {
 
-    /**
-     * Creates a new chrome-remote driver.
-     */
-    public ChromeRemoteDriver() {
-        super(true);
-    }
-
     @Override
     public String getName() {
         return "chrome-remote";
@@ -36,5 +29,10 @@ public class ChromeRemoteDriver extends AbstractDriver {
         options.addArguments("--disable-dev-shm-usage"); // overcome limited resource problems
         options.addArguments("--headless");
         return options;
+    }
+
+    @Override
+    protected boolean isRemoteDriver() {
+        return true;
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/EdgeDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/EdgeDriver.java
@@ -9,13 +9,6 @@ import org.openqa.selenium.edge.EdgeOptions;
  */
 public class EdgeDriver extends AbstractDriver {
 
-    /**
-     * Creates a new edge driver.
-     */
-    public EdgeDriver() {
-        super(false);
-    }
-
     @Override
     public String getName() {
         return "edge";
@@ -33,5 +26,10 @@ public class EdgeDriver extends AbstractDriver {
         // Make selenium use the selenium-http-jdk-client package
         System.setProperty("webdriver.http.factory", "jdk-http-client");
         return new EdgeOptions();
+    }
+
+    @Override
+    protected boolean isRemoteDriver() {
+        return false;
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/EdgeRemoteDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/EdgeRemoteDriver.java
@@ -11,13 +11,6 @@ import org.openqa.selenium.remote.RemoteWebDriver;
  */
 public class EdgeRemoteDriver extends AbstractDriver {
 
-    /**
-     * Creates a new edge-remote driver.
-     */
-    public EdgeRemoteDriver() {
-        super(false);
-    }
-
     @Override
     public String getName() {
         return "edge-remote";
@@ -31,5 +24,10 @@ public class EdgeRemoteDriver extends AbstractDriver {
     @Override
     protected Capabilities getCapabilities() {
         return new EdgeOptions();
+    }
+
+    @Override
+    protected boolean isRemoteDriver() {
+        return true;
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxAndroidDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxAndroidDriver.java
@@ -15,4 +15,9 @@ public class FirefoxAndroidDriver extends AbstractAndroidDriver {
     public WebDriver getDriverInstance() {
         return getAndroidDriver(getDesiredCapabilitiesBrowser("Firefox"));
     }
+
+    @Override
+    protected boolean isRemoteDriver() {
+        return false;
+    }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxDriver.java
@@ -9,13 +9,6 @@ import org.openqa.selenium.firefox.FirefoxOptions;
  */
 public class FirefoxDriver extends AbstractDriver {
 
-    /**
-     * Creates a new firefox driver.
-     */
-    public FirefoxDriver() {
-        super(false);
-    }
-
     @Override
     public String getName() {
         return "firefox";
@@ -33,5 +26,10 @@ public class FirefoxDriver extends AbstractDriver {
         // Make selenium use the selenium-http-jdk-client package
         System.setProperty("webdriver.http.factory", "jdk-http-client");
         return new FirefoxOptions();
+    }
+
+    @Override
+    protected boolean isRemoteDriver() {
+        return false;
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxRemoteDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxRemoteDriver.java
@@ -11,13 +11,6 @@ import org.openqa.selenium.remote.RemoteWebDriver;
  */
 public class FirefoxRemoteDriver extends AbstractDriver {
 
-    /**
-     * Creates a new firefox-remote driver.
-     */
-    public FirefoxRemoteDriver() {
-        super(true);
-    }
-
     @Override
     public String getName() {
         return "firefox-remote";
@@ -31,5 +24,10 @@ public class FirefoxRemoteDriver extends AbstractDriver {
     @Override
     protected Capabilities getCapabilities() {
         return new FirefoxOptions();
+    }
+
+    @Override
+    protected boolean isRemoteDriver() {
+        return true;
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/InternetExplorerDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/InternetExplorerDriver.java
@@ -9,13 +9,6 @@ import org.openqa.selenium.ie.InternetExplorerOptions;
  */
 public class InternetExplorerDriver extends AbstractDriver {
 
-    /**
-     * Creates a new ie driver.
-     */
-    public InternetExplorerDriver() {
-        super(false);
-    }
-
     @Override
     public String getName() {
         return "ie";
@@ -36,5 +29,10 @@ public class InternetExplorerDriver extends AbstractDriver {
         InternetExplorerOptions caps = new InternetExplorerOptions();
         caps.setCapability("ignoreZoomSetting", true);
         return caps;
+    }
+
+    @Override
+    protected boolean isRemoteDriver() {
+        return false;
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/SaucelabsDriver.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/SaucelabsDriver.java
@@ -8,13 +8,6 @@ import org.openqa.selenium.remote.RemoteWebDriver;
 
 public class SaucelabsDriver extends AbstractDriver {
 
-    /**
-     * Creates a new sauce driver.
-     */
-    public SaucelabsDriver() {
-        super(false);
-    }
-
     @Override
     public String getName() {
         return "sauce";
@@ -38,5 +31,10 @@ public class SaucelabsDriver extends AbstractDriver {
         capabilities.setCapability("sauce:options", sauceOptions);
 
         return capabilities;
+    }
+
+    @Override
+    protected boolean isRemoteDriver() {
+        return false;
     }
 }


### PR DESCRIPTION
Closes #86: all driver constructors are now default constructors so that they don't require any arguments anymore.