### PR TITLE
Change developer contact from `info@qytera.de` to `dev@qytera.de`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <name>Qytera Development</name>
             <email>dev@qytera.de</email>
             <organization>Qytera Software Testing Solutions GmbH</organization>
-            <organizationUrl>https://qytera.de/</organizationUrl>
+            <organizationUrl>https://www.qytera.de/</organizationUrl>
         </developer>
     </developers>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,9 +23,9 @@
     <developers>
         <developer>
             <name>Qytera Development</name>
-            <email>info@qytera.de</email>
+            <email>dev@qytera.de</email>
             <organization>Qytera Software Testing Solutions GmbH</organization>
-            <organizationUrl>https://www.qytera.de/</organizationUrl>
+            <organizationUrl>https://qytera.de/</organizationUrl>
         </developer>
     </developers>
 


### PR DESCRIPTION
Address `dev@qyterea.de` should be preferred over `info@qyterea.de`, since all developers are automatically subscribed to it.