### PR TITLE
Make delombok plugin less verbose

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,6 @@
                             <outputDirectory>${delombokDirectory}</outputDirectory>
                             <addOutputDirectory>false</addOutputDirectory>
                             <encoding>UTF-8</encoding>
-                            <verbose>true</verbose>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
Prevents Maven builds from cluttering up the logs with delombok messages like this:

```asm
File: /home/runner/work/QTAF/QTAF/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/helper/SeleniumDriverConfigHelper.java [delomboked]
File: /home/runner/work/QTAF/QTAF/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/FirefoxDriver.java [unchanged]
File: /home/runner/work/QTAF/QTAF/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/EdgeDriver.java [unchanged]
File: /home/runner/work/QTAF/QTAF/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AbstractAndroidDriver.java [unchanged]
File: /home/runner/work/QTAF/QTAF/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AbstractDriver.java [unchanged]
File: /home/runner/work/QTAF/QTAF/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/AndroidDriver.java [unchanged]
```