### PR TITLE
Add sonar cloud quality analysis

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -49,6 +49,7 @@ jobs:
           mvn --batch-mode \
           -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \
           -DskipTests \
+          --activate-profiles release-profile \
           clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -72,3 +72,8 @@ jobs:
           XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
           XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+      - uses: SonarSource/sonarqube-quality-gate-action@v1.1.0
+        # Force to fail step after specific time.
+        timeout-minutes: 5
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -30,13 +30,13 @@ jobs:
             # Exclude Firefox, as it currently does not work on Windows: https://github.com/browser-actions/setup-firefox/issues/252
             command: |
               mvn clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -q `
-              "-Dxray.authentication.xray.clientId=$Env:XRAY_CLIENT_ID" `
-              "-Dxray.authentication.xray.clientSecret=$Env:XRAY_CLIENT_SECRET" `
-              "-DexcludedGroups=firefox" `
               "-Dsonar.host.url=https://sonarcloud.io" `
               "-Dsonar.organization=qytera-gmbh" `
               "-Dsonar.projectKey=Qytera-Gmbh_QTAF" `
-              "-Dsonar.login=$Env:SONAR_TOKEN"
+              "-Dsonar.login=$Env:SONAR_TOKEN" `
+              "-Dxray.authentication.xray.clientId=$Env:XRAY_CLIENT_ID" `
+              "-Dxray.authentication.xray.clientSecret=$Env:XRAY_CLIENT_SECRET" `
+              "-DexcludedGroups=firefox"
           - os: "ubuntu-latest"
             # Exclude Internet Explorer, as it does not run on Linux: https://www.selenium.dev/documentation/ie_driver_server/
             # Also: https://stackoverflow.com/questions/63125480/running-a-gui-application-on-a-ci-service-without-x11
@@ -44,13 +44,13 @@ jobs:
               export DISPLAY=:99
               sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
               mvn clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -q \
-              -Dxray.authentication.xray.clientId=$XRAY_CLIENT_ID \
-              -Dxray.authentication.xray.clientSecret=$XRAY_CLIENT_SECRET \
-              -DexcludedGroups=ie \
               -Dsonar.host.url=https://sonarcloud.io \
               -Dsonar.organization=qytera-gmbh \
               -Dsonar.projectKey=Qytera-Gmbh_QTAF \
-              -Dsonar.login=$SONAR_TOKEN
+              -Dsonar.login=$SONAR_TOKEN \
+              -Dxray.authentication.xray.clientId=$XRAY_CLIENT_ID \
+              -Dxray.authentication.xray.clientSecret=$XRAY_CLIENT_SECRET \
+              -DexcludedGroups=ie
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -33,7 +33,7 @@ jobs:
               "-Dxray.authentication.xray.clientId=$Env:XRAY_CLIENT_ID" `
               "-Dxray.authentication.xray.clientSecret=$Env:XRAY_CLIENT_SECRET" `
               "-DexcludedGroups=firefox" `
-              "-Dsonar.host.url=Dhttps://sonarcloud.io" `
+              "-Dsonar.host.url=https://sonarcloud.io" `
               "-Dsonar.organization=qytera-gmbh" `
               "-Dsonar.projectKey=Qytera-Gmbh_QTAF" `
               "-Dsonar.login=$Env:SONAR_TOKEN"
@@ -47,7 +47,7 @@ jobs:
               -Dxray.authentication.xray.clientId=$XRAY_CLIENT_ID \
               -Dxray.authentication.xray.clientSecret=$XRAY_CLIENT_SECRET \
               -DexcludedGroups=ie \
-              -Dsonar.host.url=Dhttps://sonarcloud.io \
+              -Dsonar.host.url=https://sonarcloud.io \
               -Dsonar.organization=qytera-gmbh \
               -Dsonar.projectKey=Qytera-Gmbh_QTAF \
               -Dsonar.login=$SONAR_TOKEN

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -16,6 +16,9 @@ on:
       XRAY_CLIENT_SECRET:
         required: true
         description: "Xray Cloud API client secret"
+      SONAR_TOKEN:
+        required: true
+        description: "Sonar personal access token"
 
 jobs:
   test:
@@ -26,20 +29,29 @@ jobs:
           - os: "windows-latest"
             # Exclude Firefox, as it currently does not work on Windows: https://github.com/browser-actions/setup-firefox/issues/252
             command: |
-              mvn clean test -q `
+              mvn clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -q `
               "-Dxray.authentication.xray.clientId=$Env:XRAY_CLIENT_ID" `
               "-Dxray.authentication.xray.clientSecret=$Env:XRAY_CLIENT_SECRET" `
-              "-DexcludedGroups=firefox"
+              "-DexcludedGroups=firefox" `
+              "-Dsonar.host.url=Dhttps://sonarcloud.io" `
+              "-Dsonar.organization=qytera-gmbh" `
+              "-Dsonar.projectKey=Qytera-Gmbh_QTAF" `
+              "-Dsonar.login=$Env:SONAR_TOKEN"
           - os: "ubuntu-latest"
             # Exclude Internet Explorer, as it does not run on Linux: https://www.selenium.dev/documentation/ie_driver_server/
             # Also: https://stackoverflow.com/questions/63125480/running-a-gui-application-on-a-ci-service-without-x11
             command: |
               export DISPLAY=:99
               sudo Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-              mvn clean test -q \
+              mvn clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -q \
               -Dxray.authentication.xray.clientId=$XRAY_CLIENT_ID \
               -Dxray.authentication.xray.clientSecret=$XRAY_CLIENT_SECRET \
-              -DexcludedGroups=ie
+              -DexcludedGroups=ie \
+              -Dsonar.host.url=Dhttps://sonarcloud.io \
+              -Dsonar.organization=qytera-gmbh \
+              -Dsonar.projectKey=Qytera-Gmbh_QTAF \
+              -Dsonar.login=$SONAR_TOKEN
+
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
     steps:
@@ -59,3 +71,4 @@ jobs:
         env:
           XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
           XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -72,8 +72,3 @@ jobs:
           XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
           XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-      - uses: SonarSource/sonarqube-quality-gate-action@v1.1.0
-        # Force to fail step after specific time.
-        timeout-minutes: 5
-        env:
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,6 @@
                             <outputDirectory>${delombokDirectory}</outputDirectory>
                             <addOutputDirectory>false</addOutputDirectory>
                             <encoding>UTF-8</encoding>
-                            <verbose>true</verbose>
                         </configuration>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <developers>
         <developer>
             <name>Qytera Development</name>
-            <email>info@qytera.de</email>
+            <email>dev@qytera.de</email>
             <organization>Qytera Software Testing Solutions GmbH</organization>
             <organizationUrl>https://www.qytera.de/</organizationUrl>
         </developer>

--- a/pom.xml
+++ b/pom.xml
@@ -55,6 +55,8 @@
         <mavenCompilerPluginVersion>3.11.0</mavenCompilerPluginVersion>
         <lombokPluginVersion>1.18.20.0</lombokPluginVersion>
         <surefirePluginVersion>3.0.0</surefirePluginVersion>
+        <jacocoMavenPluginVersion>0.8.10</jacocoMavenPluginVersion>
+        <sonarMavenPluginVersion>3.9.1.2184</sonarMavenPluginVersion>
     </properties>
 
     <profiles>
@@ -165,6 +167,51 @@
                         </executions>
                         <configuration>
                             <sourcepath>${delombokDirectory}</sourcepath>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <!--
+        A profile for code quality.
+        See: https://docs.sonarcloud.io/advanced-setup/ci-based-analysis/sonarscanner-for-maven/
+        -->
+        <profile>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <id>quality-profile</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacocoMavenPluginVersion}</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <formats>
+                                        <format>XML</format>
+                                    </formats>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonarsource.scanner.maven</groupId>
+                        <artifactId>sonar-maven-plugin</artifactId>
+                        <version>${sonarMavenPluginVersion}</version>
+                        <configuration>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -217,6 +217,58 @@
                 </plugins>
             </build>
         </profile>
+        <!-- A profile for signing and deploying artifacts to Sonatype. -->
+        <profile>
+            <id>release-profile</id>
+            <activation>
+                <activeByDefault>false</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <!-- This maven plugin is responsible for generating the GPG signatures -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>3.0.1</version>
+                        <executions>
+                            <execution>
+                                <id>sgn-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                                <configuration>
+                                    <keyname>0x643DE5DE</keyname>
+                                    <passphraseServerId>0x643DE5DE</passphraseServerId>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <!-- This maven plugin deploys the artifacts to OSSRH -->
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.13</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+                <repository>
+                    <id>ossrh</id>
+                    <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+            </distributionManagement>
+        </profile>
     </profiles>
 
     <dependencies>
@@ -265,39 +317,6 @@
                 </configuration>
             </plugin>
 
-            <!-- This maven plugin is responsible for generating the GPG signatures -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.0.1</version>
-                <executions>
-                    <execution>
-                        <id>sgn-artifacts</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>sign</goal>
-                        </goals>
-                        <configuration>
-                            <keyname>0x643DE5DE</keyname>
-                            <passphraseServerId>0x643DE5DE</passphraseServerId>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <!-- This maven plugin deploys the artifacts to OSSRH -->
-            <plugin>
-                <groupId>org.sonatype.plugins</groupId>
-                <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.13</version>
-                <extensions>true</extensions>
-                <configuration>
-                    <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                </configuration>
-            </plugin>
-
             <!-- A plugin for running testng test (suites, groups, ...). -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -307,16 +326,5 @@
 
         </plugins>
     </build>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-        </repository>
-    </distributionManagement>
 
 </project>


### PR DESCRIPTION
This PR adds a Sonar analysis profile (including code coverage) to the root `pom.xml` and the necessary Maven parameters to the actions as described [here](https://docs.sonarcloud.io/advanced-setup/ci-based-analysis/sonarscanner-for-maven/) and [here](https://docs.sonarcloud.io/enriching/test-coverage/java-test-coverage/#add-coverage-in-a-multi-module-maven-project).

For a successful check, see the logs of this PR: https://github.com/Qytera-Gmbh/QTAF/pull/111/checks?check_run_id=13407507507. Please note that it only scans _new_ code. Since this PR does not add any Java code, all metrics display 0 (%).