### PR TITLE
Fix called workflow definition with `secrets: inherit`

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -9,16 +9,6 @@ on:
         required: false
         type: string
         default: "zulu"
-    secrets:
-      XRAY_CLIENT_ID:
-        required: true
-        description: "Xray Cloud API client ID"
-      XRAY_CLIENT_SECRET:
-        required: true
-        description: "Xray Cloud API client secret"
-      SONAR_TOKEN:
-        required: true
-        description: "Sonar personal access token"
 
 jobs:
   test:


### PR DESCRIPTION
This PR fixes the currently failing workflows:
![image](https://github.com/Qytera-Gmbh/QTAF/assets/18561435/893b414b-7af9-4ccd-ab3c-e1751200a136)


The main problem is the way we are passing secrets between workflows. When using `secrets: inherit`, one should not (need not?) define secret inputs in called workflows, see:
- https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idsecretsinherit
- https://docs.github.com/en/actions/using-workflows/reusing-workflows#using-inputs-and-secrets-in-a-reusable-workflow

Our workflows are currently mixing both worlds:

- We are passing secrets using `secrets: inherit` here: https://github.com/Qytera-Gmbh/QTAF/blob/97dc6bc7e5ab837e3762449ba24037440c5370ed/.github/workflows/TestJavaVersions.yml#L20

- But we are explicitly expecting secrets here: https://github.com/Qytera-Gmbh/QTAF/blob/97dc6bc7e5ab837e3762449ba24037440c5370ed/.github/workflows/Test.yml#L12-L21

To fix the currently failing workflows, we need to either:
- Pass the secrets explicitly:
  ```yml
  secrets:
    XRAY_CLIENT_ID: ${{ secrets.XRAY_CLIENT_ID }}
    XRAY_CLIENT_SECRET: ${{ secrets.XRAY_CLIENT_SECRET }}
    SONAR_TOKEN: ${{ secrets.SONAR_TOKEN}}
  ```
- Remove the explicit inputs altogether

This PR removes the explicit inputs, which does not require changing two files in the future when a new secret is required in the called workflow.
