### PR TITLE
Run Sonarcloud analysis on `develop`

### DIFF
--- a/.github/workflows/TestJavaVersions.yml
+++ b/.github/workflows/TestJavaVersions.yml
@@ -2,6 +2,12 @@
 name: Test Java Versions
 
 on:
+  push:
+    branches:
+      - develop
+    paths:
+      - qtaf-*/**
+      - pom.xml
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
There is currently a bug preventing Sonarcloud from seeing changes made to the `develop` branch.

Effectively, the bug leads to outdated information and subsequent Sonarcloud analysis failures in new PRs. These PRs are currently being compared against an outdated `develop` by Sonarcloud, resulting in failures such as `Code coverage failed: 1% of new lines (140) covered` although the PR might have only added 3 new lines with 100% coverage.

This PR fixes the bug by simply running the QTAF unit tests again for pushes on `develop` which affect the codebase.