### PR TITLE
Add JavaDoc verification to build process

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -50,6 +50,7 @@ jobs:
           -Dgpg.passphrase=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \
           -DskipTests \
           --activate-profiles release-profile \
+          --activate-profiles delombok-profile \
           clean deploy
         env:
           MAVEN_USERNAME: ${{ secrets.OSSRH_USERNAME }}

--- a/pom.xml
+++ b/pom.xml
@@ -76,7 +76,7 @@
         -->
         <profile>
             <id>delombok-profile</id>
-            <!-- Activate the profile only if '--activate-profiles delombok-profil' is passed. -->
+            <!-- Activate the profile only if activated through the command line. -->
             <activation>
                 <activeByDefault>false</activeByDefault>
             </activation>
@@ -255,7 +255,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>${mavenJarPluginVersion}</version>
-
                 <configuration>
                     <archive>
                         <manifest>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,9 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
-        <!-- versions -->
+        <!-- Allows specifying different source directories to compile, e.g. when compiling 'delomboked' code. -->
+        <qtafSourceDirectory>${project.basedir}/src/main/java</qtafSourceDirectory>
+        <!-- Versions. -->
         <lombokVersion>1.18.26</lombokVersion>
         <mavenCompilerPluginVersion>3.11.0</mavenCompilerPluginVersion>
         <lombokPluginVersion>1.18.20.0</lombokPluginVersion>
@@ -61,25 +63,31 @@
 
     <profiles>
         <!--
-        A profile that automatically 'delomboks' submodules (i.e. converts them into vanilla Java). Delombokization is
-        necessary because otherwise, the compiled and packaged class files would not match the packaged sources. This
-        is problematic when QTAF is used as a dependency and developers would like to step through QTAF code during
-        debugging. They would not be able to put 'proper' breakpoints into QTAF code, since the executed code
-        (classfile) would not be consistent with the visible code (source file).
-
-        The root module is excluded as it simply does not contain any sources to package into a JAR. Submodules are
-        identified through absence of the 'qtaf-core' directory.
+        A profile that 'delomboks' submodules (i.e. converts them into vanilla Java).
+        Delombokization is necessary because otherwise, the compiled/packaged class files would not match the
+        packaged sources. This is problematic when QTAF is used as a dependency and developers would like to step
+        through QTAF code during debugging. They would not be able to put 'proper' breakpoints into QTAF code, since
+        the executed code (classfile) would not be consistent with the visible code (source file).
         -->
         <profile>
             <id>delombok-profile</id>
+            <!--
+            Activate the profile if '-Ddelombok' is passed and if the current module is not the 'qtaf' root module.
+            The root module is excluded as it simply does not contain any sources to package into a JAR.
+            -->
             <activation>
                 <activeByDefault>false</activeByDefault>
+                <property>
+                    <name>delombok</name>
+                </property>
+                <!-- Submodules are identified through absence of the 'qtaf-core' directory. -->
                 <file>
                     <missing>qtaf-core</missing>
                 </file>
             </activation>
             <properties>
-                <delombokDirectory>${project.build.directory}/delombok</delombokDirectory>
+                <delombokDirectory>${project.build.directory}/sources-delomboked</delombokDirectory>
+                <qtafSourceDirectory>${delombokDirectory}</qtafSourceDirectory>
             </properties>
             <build>
                 <plugins>
@@ -103,51 +111,32 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <!-- A plugin for packaging the delomboked sources into a JAR file. -->
+                    <!-- A plugin for attach the delomboked source files to the build artifacts. -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-antrun-plugin</artifactId>
-                        <version>3.1.0</version>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <version>3.2.1</version>
                         <executions>
                             <execution>
-                                <id>generate-delomboked-sources-jar</id>
-                                <phase>package</phase>
+                                <id>attach-sources</id>
+                                <phase>verify</phase>
                                 <goals>
-                                    <goal>run</goal>
+                                    <goal>jar-no-fork</goal>
                                 </goals>
-                                <configuration>
-                                    <target>
-                                        <jar
-                                                destfile="${project.build.directory}/${project.build.finalName}-sources.jar"
-                                                basedir="${delombokDirectory}"
-                                        />
-                                    </target>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
-                    <!-- A plugin for attaching the packaged sources to the overall build artifacts. -->
+                    <!-- A plugin for creating Javadoc files from the delombokized sources. -->
                     <plugin>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>build-helper-maven-plugin</artifactId>
-                        <version>3.3.0</version>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>3.5.0</version>
                         <executions>
                             <execution>
-                                <id>attach-source-jar</id>
-                                <phase>package</phase>
+                                <id>attach-javadocs</id>
                                 <goals>
-                                    <goal>attach-artifact</goal>
+                                    <goal>jar</goal>
                                 </goals>
-                                <configuration>
-                                    <artifacts>
-                                        <artifact>
-                                            <file>${project.build.directory}/${project.build.finalName}-sources.jar
-                                            </file>
-                                            <type>jar</type>
-                                            <classifier>sources</classifier>
-                                        </artifact>
-                                    </artifacts>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>
@@ -280,6 +269,7 @@
     </dependencies>
 
     <build>
+        <sourceDirectory>${qtafSourceDirectory}</sourceDirectory>
         <resources>
             <resource>
                 <directory>src/main/resources</directory>

--- a/pom.xml
+++ b/pom.xml
@@ -53,12 +53,17 @@
         <!-- Allows specifying different source directories to compile, e.g. when compiling 'delomboked' code. -->
         <qtafSourceDirectory>${project.basedir}/src/main/java</qtafSourceDirectory>
         <!-- Versions. -->
+        <jacocoMavenPluginVersion>0.8.10</jacocoMavenPluginVersion>
+        <lombokPluginVersion>1.18.20.0</lombokPluginVersion>
         <lombokVersion>1.18.26</lombokVersion>
         <mavenCompilerPluginVersion>3.11.0</mavenCompilerPluginVersion>
-        <lombokPluginVersion>1.18.20.0</lombokPluginVersion>
-        <surefirePluginVersion>3.0.0</surefirePluginVersion>
-        <jacocoMavenPluginVersion>0.8.10</jacocoMavenPluginVersion>
+        <mavenGpgPluginVersion>3.0.1</mavenGpgPluginVersion>
+        <mavenJarPluginVersion>3.3.0</mavenJarPluginVersion>
+        <mavenJavadocPluginVersion>3.5.0</mavenJavadocPluginVersion>
+        <mavenSourcePluginVersion>3.2.1</mavenSourcePluginVersion>
+        <nexusStagingMavenPluginVersion>1.6.13</nexusStagingMavenPluginVersion>
         <sonarMavenPluginVersion>3.9.1.2184</sonarMavenPluginVersion>
+        <surefirePluginVersion>3.0.0</surefirePluginVersion>
     </properties>
 
     <profiles>
@@ -71,19 +76,9 @@
         -->
         <profile>
             <id>delombok-profile</id>
-            <!--
-            Activate the profile if '-Ddelombok' is passed and if the current module is not the 'qtaf' root module.
-            The root module is excluded as it simply does not contain any sources to package into a JAR.
-            -->
+            <!-- Activate the profile only if '--activate-profiles delombok-profil' is passed. -->
             <activation>
                 <activeByDefault>false</activeByDefault>
-                <property>
-                    <name>delombok</name>
-                </property>
-                <!-- Submodules are identified through absence of the 'qtaf-core' directory. -->
-                <file>
-                    <missing>qtaf-core</missing>
-                </file>
             </activation>
             <properties>
                 <delombokDirectory>${project.build.directory}/sources-delomboked</delombokDirectory>
@@ -115,7 +110,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-source-plugin</artifactId>
-                        <version>3.2.1</version>
+                        <version>${mavenSourcePluginVersion}</version>
                         <executions>
                             <execution>
                                 <id>attach-sources</id>
@@ -168,8 +163,6 @@
                         <groupId>org.sonarsource.scanner.maven</groupId>
                         <artifactId>sonar-maven-plugin</artifactId>
                         <version>${sonarMavenPluginVersion}</version>
-                        <configuration>
-                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -182,20 +175,6 @@
             </activation>
             <build>
                 <plugins>
-                    <!-- A plugin for creating Javadoc files. -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>${mavenJavadocPluginVersion}</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
                     <!-- This maven plugin is responsible for generating the GPG signatures -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
@@ -271,12 +250,11 @@
                     <target>${maven.compiler.target}</target>
                 </configuration>
             </plugin>
-
             <!-- Plugin to build a JAR file -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <version>3.3.0</version>
+                <version>${mavenJarPluginVersion}</version>
 
                 <configuration>
                     <archive>
@@ -288,14 +266,26 @@
                     </archive>
                 </configuration>
             </plugin>
-
             <!-- A plugin for running testng test (suites, groups, ...). -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefirePluginVersion}</version>
             </plugin>
-
+            <!-- A plugin for creating Javadoc files. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${mavenJavadocPluginVersion}</version>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -126,37 +126,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <!-- A plugin for creating Javadoc files from the delombokized sources. -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.5.0</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                    <!-- A plugin for creating Javadoc files from the delombokized sources. -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-javadoc-plugin</artifactId>
-                        <version>3.5.0</version>
-                        <executions>
-                            <execution>
-                                <id>attach-javadocs</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <sourcepath>${delombokDirectory}</sourcepath>
-                        </configuration>
-                    </plugin>
                 </plugins>
             </build>
         </profile>
@@ -213,11 +182,25 @@
             </activation>
             <build>
                 <plugins>
+                    <!-- A plugin for creating Javadoc files. -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <version>${mavenJavadocPluginVersion}</version>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
                     <!-- This maven plugin is responsible for generating the GPG signatures -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.0.1</version>
+                        <version>${mavenGpgPluginVersion}</version>
                         <executions>
                             <execution>
                                 <id>sgn-artifacts</id>
@@ -236,7 +219,7 @@
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.13</version>
+                        <version>${nexusStagingMavenPluginVersion}</version>
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <!-- Allows specifying different source directories to compile, e.g. when compiling 'delomboked' code. -->
         <qtafSourceDirectory>${project.basedir}/src/main/java</qtafSourceDirectory>
+        <!-- JavaDoc linting needs to be disabled after Delombokization, but can be enabled beforehand/by default. -->
+        <javadocPluginDoclint>all</javadocPluginDoclint>
         <!-- Versions. -->
         <jacocoMavenPluginVersion>0.8.10</jacocoMavenPluginVersion>
         <lombokPluginVersion>1.18.20.0</lombokPluginVersion>
@@ -59,6 +61,7 @@
         <mavenCompilerPluginVersion>3.11.0</mavenCompilerPluginVersion>
         <mavenGpgPluginVersion>3.0.1</mavenGpgPluginVersion>
         <mavenJarPluginVersion>3.3.0</mavenJarPluginVersion>
+        <mavenJavadocPluginVersion>3.5.0</mavenJavadocPluginVersion>
         <mavenSourcePluginVersion>3.2.1</mavenSourcePluginVersion>
         <nexusStagingMavenPluginVersion>1.6.13</nexusStagingMavenPluginVersion>
         <sonarMavenPluginVersion>3.9.1.2184</sonarMavenPluginVersion>
@@ -82,6 +85,7 @@
             <properties>
                 <delombokDirectory>${project.build.directory}/sources-delomboked</delombokDirectory>
                 <qtafSourceDirectory>${delombokDirectory}</qtafSourceDirectory>
+                <javadocPluginDoclint>none</javadocPluginDoclint>
             </properties>
             <build>
                 <plugins>
@@ -269,6 +273,23 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefirePluginVersion}</version>
+            </plugin>
+            <!-- A plugin for creating Javadoc files. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${mavenJavadocPluginVersion}</version>
+                <configuration>
+                    <doclint>${javadocPluginDoclint}</doclint>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,6 @@
         <mavenCompilerPluginVersion>3.11.0</mavenCompilerPluginVersion>
         <mavenGpgPluginVersion>3.0.1</mavenGpgPluginVersion>
         <mavenJarPluginVersion>3.3.0</mavenJarPluginVersion>
-        <mavenJavadocPluginVersion>3.5.0</mavenJavadocPluginVersion>
         <mavenSourcePluginVersion>3.2.1</mavenSourcePluginVersion>
         <nexusStagingMavenPluginVersion>1.6.13</nexusStagingMavenPluginVersion>
         <sonarMavenPluginVersion>3.9.1.2184</sonarMavenPluginVersion>
@@ -270,20 +269,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>${surefirePluginVersion}</version>
-            </plugin>
-            <!-- A plugin for creating Javadoc files. -->
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>${mavenJavadocPluginVersion}</version>
-                <executions>
-                    <execution>
-                        <id>attach-javadocs</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/test/XrayTestEntityBuilder.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/builder/test/XrayTestEntityBuilder.java
@@ -78,7 +78,7 @@ public abstract class XrayTestEntityBuilder<T> {
      * @param xrayTest     the {@link XrayTest} annotation of the test
      * @param scenarioData the scenario data to extract the status from
      * @return the test's status
-     * @see XrayTestEntity#getStatus()
+     * @see XrayTestEntity
      */
     protected abstract TestScenarioLogCollection.Status getStatus(XrayTest xrayTest, T scenarioData);
 
@@ -98,7 +98,7 @@ public abstract class XrayTestEntityBuilder<T> {
      * @param xrayTest     the {@link XrayTest} annotation of the test
      * @param scenarioData the scenario data to extract the start date from
      * @return the test's start date
-     * @see XrayTestEntity#getStart()
+     * @see XrayTestEntity
      */
     protected abstract Date getStartDate(XrayTest xrayTest, T scenarioData);
 
@@ -108,7 +108,7 @@ public abstract class XrayTestEntityBuilder<T> {
      * @param xrayTest     the {@link XrayTest} annotation of the test
      * @param scenarioData the scenario data to extract the end date from
      * @return the test's end date
-     * @see XrayTestEntity#getFinish()
+     * @see XrayTestEntity
      */
     protected abstract Date getEndDate(XrayTest xrayTest, T scenarioData);
 
@@ -118,7 +118,7 @@ public abstract class XrayTestEntityBuilder<T> {
      * @param xrayTest     the {@link XrayTest} annotation of the test
      * @param scenarioData the scenario data to extract the comment from
      * @return the test's comment
-     * @see XrayTestEntity#getComment()
+     * @see XrayTestEntity
      */
     protected abstract String getComment(XrayTest xrayTest, T scenarioData);
 
@@ -128,7 +128,7 @@ public abstract class XrayTestEntityBuilder<T> {
      * @param xrayTest     the {@link XrayTest} annotation of the test
      * @param scenarioData the scenario data to extract the user id from
      * @return the user id of the user who executed the test
-     * @see XrayTestEntity#getExecutedBy()
+     * @see XrayTestEntity
      */
     protected abstract String getExecutedBy(XrayTest xrayTest, T scenarioData);
 
@@ -138,7 +138,7 @@ public abstract class XrayTestEntityBuilder<T> {
      * @param xrayTest     the {@link XrayTest} annotation of the test
      * @param scenarioData the scenario data to extract the assignee from
      * @return the test's assignee
-     * @see XrayTestEntity#getAssignee()
+     * @see XrayTestEntity
      */
     protected abstract String getAssignee(XrayTest xrayTest, T scenarioData);
 
@@ -148,7 +148,7 @@ public abstract class XrayTestEntityBuilder<T> {
      * @param xrayTest     the {@link XrayTest} annotation of the test
      * @param scenarioData the scenario data to extract the steps from
      * @return the test's steps
-     * @see XrayTestEntity#getSteps()
+     * @see XrayTestEntity
      */
     protected abstract List<XrayManualTestStepResultEntity> getSteps(XrayTest xrayTest, T scenarioData);
 
@@ -158,7 +158,7 @@ public abstract class XrayTestEntityBuilder<T> {
      * @param xrayTest     the {@link XrayTest} annotation of the test
      * @param scenarioData the scenario data to extract the examples from
      * @return the test's examples
-     * @see XrayTestEntity#getExamples()
+     * @see XrayTestEntity
      */
     protected abstract List<String> getExamples(XrayTest xrayTest, T scenarioData);
 
@@ -168,7 +168,7 @@ public abstract class XrayTestEntityBuilder<T> {
      * @param xrayTest     the {@link XrayTest} annotation of the test
      * @param scenarioData the scenario data to extract the iterations from
      * @return the test's iterations
-     * @see XrayTestEntity#getIterations()
+     * @see XrayTestEntity
      */
     protected abstract List<XrayIterationResultEntity> getIterations(XrayTest xrayTest, T scenarioData);
 
@@ -178,7 +178,7 @@ public abstract class XrayTestEntityBuilder<T> {
      * @param xrayTest     the {@link XrayTest} annotation of the test
      * @param scenarioData the scenario data to extract the defects from
      * @return the test's defects
-     * @see XrayTestEntity#getDefects()
+     * @see XrayTestEntity
      */
     protected abstract List<String> getDefects(XrayTest xrayTest, T scenarioData);
 
@@ -188,7 +188,7 @@ public abstract class XrayTestEntityBuilder<T> {
      * @param xrayTest     the {@link XrayTest} annotation of the test
      * @param scenarioData the scenario data to extract the evidence from
      * @return the test's evidence
-     * @see XrayTestEntity#getEvidence()
+     * @see XrayTestEntity
      */
     protected abstract List<XrayEvidenceItemEntity> getEvidence(XrayTest xrayTest, T scenarioData);
 
@@ -198,7 +198,7 @@ public abstract class XrayTestEntityBuilder<T> {
      * @param xrayTest     the {@link XrayTest} annotation of the test
      * @param scenarioData the scenario data to extract the custom fields from
      * @return the test's custom field (values)
-     * @see XrayTestEntity#getCustomFields()
+     * @see XrayTestEntity
      */
     protected abstract List<XrayCustomFieldEntity> getCustomFields(XrayTest xrayTest, T scenarioData);
 


### PR DESCRIPTION
This PR allows JavaDoc to be analysed & verified, so that these error messages prevent future PRs from being accepted:

```properties
[ERROR] ~\QTAF\qtaf-xray-plugin\src\main\java\de\qytera\qtaf\xray\repository\xray\XrayCucumberRepository.java:17: warning: no @throws for java.net.URISyntaxException
[ERROR]     String getFeatureFileDefinition(String[] testIDs) throws URISyntaxException, MissingConfigurationValueException;
[ERROR]            ^
[ERROR] ~\QTAF\qtaf-xray-plugin\src\main\java\de\qytera\qtaf\xray\repository\xray\XrayCucumberRepository.java:17: warning: no @throws for de.qytera.qtaf.core.config.exception.MissingConfigurationValueException
[ERROR]     String getFeatureFileDefinition(String[] testIDs) throws URISyntaxException, MissingConfigurationValueException;
[ERROR]            ^
[ERROR] ~\QTAF\qtaf-xray-plugin\src\main\java\de\qytera\qtaf\xray\repository\xray\XrayCucumberRepositoryCloud.java:94: warning: no @throws for java.net.URISyntaxException
[ERROR]     public List<String> getFeatureFileDefinitions(String[] testIDs) throws IOException, URISyntaxException, MissingConfigurationValueException {
[ERROR]  
```

Verification does *not* take place once Delomokization was performed earlier in the Maven process. Delombokization does not add complete JavaDoc comments to getters, setters etc. and would cause builds to fail due to missing JavaDoc parameters.


