### PR TITLE
Skip `browser-actions/setup-edge` on ubuntu runners

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -40,8 +40,7 @@ jobs:
               -Dsonar.login=$SONAR_TOKEN \
               -Dxray.authentication.xray.clientId=$XRAY_CLIENT_ID \
               -Dxray.authentication.xray.clientSecret=$XRAY_CLIENT_SECRET \
-              -DexcludedGroups=ie \
-              -DexcludedGroups=edge
+              -DexcludedGroups=ie,edge
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -40,7 +40,8 @@ jobs:
               -Dsonar.login=$SONAR_TOKEN \
               -Dxray.authentication.xray.clientId=$XRAY_CLIENT_ID \
               -Dxray.authentication.xray.clientSecret=$XRAY_CLIENT_SECRET \
-              -DexcludedGroups=ie
+              -DexcludedGroups=ie \
+              -DexcludedGroups=edge
 
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
@@ -51,6 +52,8 @@ jobs:
         # See above reasoning for Firefox exclusion.
         if: matrix.os != 'windows-latest'
       - uses: browser-actions/setup-edge@v1
+        # Edge currently does not work.
+        if: matrix.os != 'ubuntu-latest'
       - uses: actions/setup-java@v3
         with:
           java-version: ${{ inputs.java-version }}


### PR DESCRIPTION
Edge currently fails on all ubuntu runners:
- https://github.com/Qytera-Gmbh/QTAF/actions/runs/5428118610/jobs/9872027830?pr=132
- https://github.com/Qytera-Gmbh/QTAF/actions/runs/5428118055/jobs/9872026674?pr=131
- https://github.com/Qytera-Gmbh/QTAF/actions/runs/5428118055/jobs/9872026674?pr=130
- etc.