### PR TITLE
Check secrets availability before running tests

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -14,7 +14,7 @@ jobs:
   check-secret:
     runs-on: ubuntu-latest
     steps:
-      - name: check secret availability
+      - name: Check secret availability
         run: |
           if [ -z "${{ secrets.XRAY_CLIENT_ID }}" ]; then
             echo '✖ XRAY_CLIENT_ID secret not available'        

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -17,16 +17,22 @@ jobs:
       - name: check secret availability
         run: |
           if [ -z "${{ secrets.XRAY_CLIENT_ID }}" ]; then
-            echo 'XRAY_CLIENT_ID secret is undefined'        
+            echo '✖ XRAY_CLIENT_ID secret not available'        
             exit 1
+          else
+            echo '✔ XRAY_CLIENT_ID secret is available'     
           fi
           if [ -z "${{ secrets.XRAY_CLIENT_SECRET }}" ]; then
-            echo 'XRAY_CLIENT_SECRET secret is undefined'        
+            echo '✖ XRAY_CLIENT_SECRET secret not available'        
             exit 1
+          else
+            echo '✔ XRAY_CLIENT_SECRET secret is available'     
           fi
           if [ -z "${{ secrets.SONAR_TOKEN }}" ]; then
-            echo 'SONAR_TOKEN secret is undefined'        
+            echo '✖ SONAR_TOKEN secret is not available'        
             exit 1
+          else
+            echo '✔ SONAR_TOKEN secret is available'        
           fi
 
   test:

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -11,7 +11,26 @@ on:
         default: "zulu"
 
 jobs:
+  check-secret:
+    runs-on: ubuntu-latest
+    steps:
+      - name: check secret availability
+        run: |
+          if [ -z "${{ secrets.XRAY_CLIENT_ID }}" ]; then
+            echo 'XRAY_CLIENT_ID secret is undefined'        
+            exit 1
+          fi
+          if [ -z "${{ secrets.XRAY_CLIENT_SECRET }}" ]; then
+            echo 'XRAY_CLIENT_SECRET secret is undefined'        
+            exit 1
+          fi
+          if [ -z "${{ secrets.SONAR_TOKEN }}" ]; then
+            echo 'SONAR_TOKEN secret is undefined'        
+            exit 1
+          fi
+
   test:
+    needs: [check-secret]
     strategy:
       matrix:
         os: ["windows-latest", "ubuntu-latest"]

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/log/model/message/StepInformationLogMessage.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/log/model/message/StepInformationLogMessage.java
@@ -138,7 +138,6 @@ public class StepInformationLogMessage extends LogMessage {
      *
      * @param name  the name of the parameter
      * @param value the value of the parameter
-     * @param <T>   the parameter type
      */
     public <T> void addStepParameter(String name, T value) {
         String className = value == null ? NullType.class.getName() : value.getClass().getSimpleName();
@@ -188,6 +187,16 @@ public class StepInformationLogMessage extends LogMessage {
      * Check if an error occurred
      *
      * @return true if an error occurred during method execution, false otherwise
+     */
+    public boolean hasError() {
+        return this.error != null;
+    }
+
+    /**
+     * Set step error
+     *
+     * @param error step error
+     * @return this
      */
     public StepInformationLogMessage setError(Throwable error) {
         this.error = new ThrowableWrapper(error);


### PR DESCRIPTION
If certain environment variables necessary for testing and sonar analysis aren't defined, the unit tests currently still run for a few minutes until they finally fail. This PR should result in "fail-fast" actions.

Example logs for a failed run: https://github.com/Qytera-Gmbh/QTAF/actions/runs/5830930637/attempts/2
Example logs for a successful run: https://github.com/Qytera-Gmbh/QTAF/actions/runs/5830930637