### PR TITLE
Move secret check to individual action

### DIFF
--- a/.github/workflows/CheckSecrets.yml
+++ b/.github/workflows/CheckSecrets.yml
@@ -1,0 +1,47 @@
+# A workflow for verifying that all given secrets are available and not blank.
+# The workflow never outputs the actual secret string value, it only reads each
+# secret once to assess whether it is blank or undefined.
+name: Check Secret Availability
+on:
+  workflow_call:
+    inputs:
+      secret-names:
+        description: |
+          A list of secrets which must be available/non-empty for the job to succeed
+          You should pass them like this:
+
+              with:
+                  secret-names: |
+                      SECRET1
+                      SECRET2
+
+        required: true
+        type: string
+
+jobs:
+  check-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check secret availability
+        run: |
+          NAMES=(${{ inputs.secret-names }})
+          ALL_AVAILABLE=1
+          echo -e "\033[36mChecking availability of secrets... \033[0m"
+          echo
+          for i in "${NAMES[@]}"
+          do
+          if [ -z "${!i}" ]; then
+              echo -e "\033[31m \u2717 $i \033[0m"
+              ALL_AVAILABLE=0
+          else
+              echo -e "\033[32m \u2713 $i \033[0m"     
+          fi
+          done
+
+          if [ "$ALL_AVAILABLE" -eq 0 ]; then
+          echo
+          echo -e "\033[31mIf dependabot initiated the workflow, make sure to add the missing secrets to Dependabot's secrets. \033[0m"
+          echo
+          echo -e "\033[31mMore information: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/configuring-access-to-private-registries-for-dependabot \033[0m"
+          exit 1
+          fi

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -11,32 +11,17 @@ on:
         default: "zulu"
 
 jobs:
-  check-secret:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check secret availability
-        run: |
-          if [ -z "${{ secrets.XRAY_CLIENT_ID }}" ]; then
-            echo '✖ XRAY_CLIENT_ID secret not available'        
-            exit 1
-          else
-            echo '✔ XRAY_CLIENT_ID secret is available'     
-          fi
-          if [ -z "${{ secrets.XRAY_CLIENT_SECRET }}" ]; then
-            echo '✖ XRAY_CLIENT_SECRET secret not available'        
-            exit 1
-          else
-            echo '✔ XRAY_CLIENT_SECRET secret is available'     
-          fi
-          if [ -z "${{ secrets.SONAR_TOKEN }}" ]; then
-            echo '✖ SONAR_TOKEN secret is not available'        
-            exit 1
-          else
-            echo '✔ SONAR_TOKEN secret is available'        
-          fi
+  check-secrets:
+    uses: ./.github/workflows/CheckSecrets.yml
+    with:
+      secret-names: |
+        XRAY_CLIENT_ID
+        XRAY_CLIENT_SECRET
+        SONAR_TOKEN
+    secrets: inherit
 
   test:
-    needs: [check-secret]
+    needs: [check-secrets]
     strategy:
       matrix:
         os: ["windows-latest", "ubuntu-latest"]


### PR DESCRIPTION
This PR moves the secret availability check to a reusable workflow. The action now also accepts arbitrary secret names to check.