### PR TITLE
Added dynamic default behaviour for failed assertions

### DIFF
--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/config/helper/QtafTestExecutionConfigHelper.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/config/helper/QtafTestExecutionConfigHelper.java
@@ -18,13 +18,16 @@ public class QtafTestExecutionConfigHelper {
      */
     protected static final ConfigMap config = QtafFactory.getConfiguration();
 
+    private static final String TEST_GROUPS = "tests.groups";
+    private static final String TEST_ASSERTION_BEHAVIOUR_ON_FAILURE = "tests.continueOnAssertionFailure";
+
     /**
      * Get all groups that should run
      *
      * @return List of names of test groups
      */
     public static List<String> getTestGroupsFromConfiguration() {
-        String configGroupString = config.getString("tests.groups");
+        String configGroupString = config.getString(TEST_GROUPS);
 
         // Groups were passed in configuration bit scenario has no groups
         if (configGroupString == null) {
@@ -33,5 +36,13 @@ public class QtafTestExecutionConfigHelper {
 
         // Parse config group names
         return TokenSeparatedStringHelper.toList(configGroupString, ",", true);
+    }
+
+    /**
+     * A boolean value that indicates weather failed assertions should finish a running test immediately or if the test should continue
+     * @return true if tests should continue when assertions fail, false otherwise
+     */
+    public static boolean continueOnAssertionFailure() {
+        return config.getBoolean(TEST_ASSERTION_BEHAVIOUR_ON_FAILURE);
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/testng/context/AssertionContext.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/testng/context/AssertionContext.java
@@ -1,5 +1,6 @@
 package de.qytera.qtaf.testng.context;
 
+import de.qytera.qtaf.core.config.helper.QtafTestExecutionConfigHelper;
 import de.qytera.qtaf.core.log.model.LogLevel;
 import de.qytera.qtaf.core.log.model.collection.TestScenarioLogCollection;
 import de.qytera.qtaf.core.log.model.message.AssertionLogMessage;
@@ -29,7 +30,7 @@ public interface AssertionContext {
      * @param message   The message that should be displayed if the assertion fails
      */
     default void assertTrue(boolean condition, String message) {
-        assertTrue(condition, message, false);
+        assertTrue(condition, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**
@@ -61,7 +62,7 @@ public interface AssertionContext {
      * @param message   The message that should be displayed if the assertion fails
      */
     default void assertFalse(boolean condition, String message) {
-        assertFalse(condition, message, false);
+        assertFalse(condition, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**
@@ -102,7 +103,7 @@ public interface AssertionContext {
      * @param message The message that should be displayed if the assertion fails
      */
     default void assertNull(Object object, String message) {
-        assertNull(object, message, false);
+        assertNull(object, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**
@@ -143,7 +144,7 @@ public interface AssertionContext {
      * @param message The message that should be displayed if the assertion fails
      */
     default void assertNotNull(Object object, String message) {
-        assertNotNull(object, message, false);
+        assertNotNull(object, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**
@@ -186,7 +187,7 @@ public interface AssertionContext {
      * @param message  The message that should be displayed if the assertion fails
      */
     default void assertSame(Object actual, Object expected, String message) {
-        assertSame(actual, expected, message, false);
+        assertSame(actual, expected, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**
@@ -230,7 +231,7 @@ public interface AssertionContext {
      * @param message  The message that should be displayed if the assertion fails
      */
     default void assertNotSame(Object actual, Object expected, String message) {
-        assertNotSame(actual, expected, message, false);
+        assertNotSame(actual, expected, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**
@@ -274,7 +275,7 @@ public interface AssertionContext {
      * @param message The message that should be displayed if the assertion fails
      */
     default void assertEquals(Object object1, Object object2, String message) {
-        assertEquals(object1, object2, message, false);
+        assertEquals(object1, object2, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**
@@ -318,7 +319,7 @@ public interface AssertionContext {
      * @param message  The message that should be displayed if the assertion fails
      */
     default void assertEqualsDeep(Set<?> actual, Set<?> expected, String message) {
-        assertEqualsDeep(actual, expected, message, false);
+        assertEqualsDeep(actual, expected, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**
@@ -339,7 +340,7 @@ public interface AssertionContext {
      * @param message  The message that should be displayed if the assertion fails
      */
     default void assertEqualsDeep(Map<?, ?> actual, Map<?, ?> expected, String message) {
-        assertEqualsDeep(actual, expected, message, false);
+        assertEqualsDeep(actual, expected, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**
@@ -406,7 +407,7 @@ public interface AssertionContext {
      * @param message  The message that should be displayed if the assertion fails
      */
     default void assertNotEqualsDeep(Set<?> actual, Set<?> expected, String message) {
-        assertNotEqualsDeep(actual, expected, message, false);
+        assertNotEqualsDeep(actual, expected, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**
@@ -427,7 +428,7 @@ public interface AssertionContext {
      * @param message  The message that should be displayed if the assertion fails
      */
     default void assertNotEqualsDeep(Map<?, ?> actual, Map<?, ?> expected, String message) {
-        assertNotEqualsDeep(actual, expected, message, false);
+        assertNotEqualsDeep(actual, expected, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**
@@ -494,7 +495,7 @@ public interface AssertionContext {
      * @param message The message that should be displayed if the assertion fails
      */
     default void assertEqualsNoOrder(Object[] object1, Object[] object2, String message) {
-        assertEqualsNoOrder(object1, object2, message, false);
+        assertEqualsNoOrder(object1, object2, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**
@@ -538,7 +539,7 @@ public interface AssertionContext {
      * @param message The message that should be displayed if the assertion fails
      */
     default void assertNotEquals(Object object1, Object object2, String message) {
-        assertNotEquals(object1, object2, message, false);
+        assertNotEquals(object1, object2, message, QtafTestExecutionConfigHelper.continueOnAssertionFailure());
     }
 
     /**

--- a/qtaf-core/src/main/resources/qtaf.json
+++ b/qtaf-core/src/main/resources/qtaf.json
@@ -4,7 +4,8 @@
       "name": ""
     },
     "package": "tests",
-    "groups": null
+    "groups": null,
+    "continueOnAssertionFailure": true
   },
   "driver": {
     "name": "chrome",

--- a/qtaf-core/src/test/java/de/qytera/qtaf/testng/AssertionContextTest.java
+++ b/qtaf-core/src/test/java/de/qytera/qtaf/testng/AssertionContextTest.java
@@ -1,5 +1,6 @@
 package de.qytera.qtaf.testng;
 
+import de.qytera.qtaf.core.config.ConfigurationFactory;
 import de.qytera.qtaf.core.log.model.collection.TestScenarioLogCollection;
 import de.qytera.qtaf.core.log.model.index.IndexHelper;
 import de.qytera.qtaf.core.log.model.message.AssertionLogMessage;
@@ -15,6 +16,16 @@ import java.util.Map;
 import java.util.Set;
 
 public class AssertionContextTest {
+    private static final String TEST_ASSERTION_BEHAVIOUR_ON_FAILURE = "tests.continueOnAssertionFailure";
+
+    private void makeFailedAssertionsBreakTests() {
+        ConfigurationFactory.getInstance().setBoolean(TEST_ASSERTION_BEHAVIOUR_ON_FAILURE, false);
+    }
+
+    private void makeFailedAssertionsContinueTests() {
+        ConfigurationFactory.getInstance().setBoolean(TEST_ASSERTION_BEHAVIOUR_ON_FAILURE, true);
+    }
+
     @BeforeMethod
     public void clearIndicesBeforeTest() {
         IndexHelper.clearAllIndices();
@@ -33,6 +44,7 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertTrue")
     public void testAssertTrue() {
+        makeFailedAssertionsBreakTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();
@@ -100,6 +112,18 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertFalse", expectedExceptions = {AssertionError.class})
     public void testAssertFalseFailure() {
+        makeFailedAssertionsBreakTests();
+        TestContext context = new TestContext();
+        StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
+        logMessage.getAssertions().clear();
+        Assert.assertEquals(logMessage.getAssertions().size(), 0);
+
+        context.assertFalse(true, "should be false");
+    }
+
+    @Test(description = "Test assertFalse continue")
+    public void testAssertFalseFailureContinue() {
+        makeFailedAssertionsContinueTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();
@@ -148,6 +172,18 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertNull failure", expectedExceptions = {AssertionError.class})
     public void testAssertNullFailure() {
+        makeFailedAssertionsBreakTests();
+        TestContext context = new TestContext();
+        StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
+        logMessage.getAssertions().clear();
+        Assert.assertEquals(logMessage.getAssertions().size(), 0);
+
+        context.assertNull("abc", "should be null");
+    }
+
+    @Test(description = "Test assertNull failure continue")
+    public void testAssertNullFailureContinue() {
+        makeFailedAssertionsContinueTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();
@@ -196,6 +232,18 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertNotNull failure", expectedExceptions = {AssertionError.class})
     public void testAssertNotNullFailure() {
+        makeFailedAssertionsBreakTests();
+        TestContext context = new TestContext();
+        StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
+        logMessage.getAssertions().clear();
+        Assert.assertEquals(logMessage.getAssertions().size(), 0);
+
+        context.assertNotNull(null, "should not be null");
+    }
+
+    @Test(description = "Test assertNotNull failure´continue")
+    public void testAssertNotNullFailureContinue() {
+        makeFailedAssertionsContinueTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();
@@ -245,6 +293,18 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertSame failure", expectedExceptions = {AssertionError.class})
     public void testAssertSameFailure() {
+        makeFailedAssertionsBreakTests();
+        TestContext context = new TestContext();
+        StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
+        logMessage.getAssertions().clear();
+        Assert.assertEquals(logMessage.getAssertions().size(), 0);
+
+        context.assertSame("abc", "def", "should be null");
+    }
+
+    @Test(description = "Test assertSame failure continue")
+    public void testAssertSameFailureContinue() {
+        makeFailedAssertionsContinueTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();
@@ -295,6 +355,18 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertNotSame failure", expectedExceptions = {AssertionError.class})
     public void testAssertNotSameFailure() {
+        makeFailedAssertionsBreakTests();
+        TestContext context = new TestContext();
+        StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
+        logMessage.getAssertions().clear();
+        Assert.assertEquals(logMessage.getAssertions().size(), 0);
+
+        context.assertNotSame("abc", "abc", "should not be same");
+    }
+
+    @Test(description = "Test assertNotSame failure continue")
+    public void testAssertNotSameFailureContinue() {
+        makeFailedAssertionsContinueTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();
@@ -345,6 +417,18 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertEquals failure", expectedExceptions = {AssertionError.class})
     public void testAssertEqualsFailure() {
+        makeFailedAssertionsBreakTests();
+        TestContext context = new TestContext();
+        StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
+        logMessage.getAssertions().clear();
+        Assert.assertEquals(logMessage.getAssertions().size(), 0);
+
+        context.assertEquals("abc", "def", "should be null");
+    }
+
+    @Test(description = "Test assertEquals failure continue")
+    public void testAssertEqualsFailureContinue() {
+        makeFailedAssertionsContinueTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();
@@ -395,6 +479,18 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertNotEquals failure", expectedExceptions = {AssertionError.class})
     public void testAssertNotEqualsFailure() {
+        makeFailedAssertionsBreakTests();
+        TestContext context = new TestContext();
+        StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
+        logMessage.getAssertions().clear();
+        Assert.assertEquals(logMessage.getAssertions().size(), 0);
+
+        context.assertNotEquals("abc", "abc", "should not be equal");
+    }
+
+    @Test(description = "Test assertNotEquals failure continue")
+    public void testAssertNotEqualsFailureContinue() {
+        makeFailedAssertionsContinueTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();
@@ -447,6 +543,20 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertEquals failure", expectedExceptions = {AssertionError.class})
     public void testAssertEqualsNoOrderFailure() {
+        makeFailedAssertionsBreakTests();
+        TestContext context = new TestContext();
+        StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
+        logMessage.getAssertions().clear();
+        Assert.assertEquals(logMessage.getAssertions().size(), 0);
+
+        Object[] obj1 = new Object[]{1, 2, 3};
+        Object[] obj2 = new Object[]{4, 5, 6};
+        context.assertEqualsNoOrder(obj1, obj2, "should be null");
+    }
+
+    @Test(description = "Test assertEquals failure continue")
+    public void testAssertEqualsNoOrderFailureContinue() {
+        makeFailedAssertionsContinueTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();
@@ -503,6 +613,20 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertEqualsDeep failure", expectedExceptions = {AssertionError.class})
     public void testAssertEqualsDeepFailureWithMap() {
+        makeFailedAssertionsBreakTests();
+        TestContext context = new TestContext();
+        StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
+        logMessage.getAssertions().clear();
+        Assert.assertEquals(logMessage.getAssertions().size(), 0);
+
+        Map<String, String> obj1 = Map.of("k1", "v1", "k2", "v2", "k3", "v3");
+        Map<String, String> obj2 = Map.of("k4", "v4");
+        context.assertEqualsDeep(obj1, obj2, "should be equal");
+    }
+
+    @Test(description = "Test assertEqualsDeep failure continue")
+    public void testAssertEqualsDeepFailureWithMapContinue() {
+        makeFailedAssertionsContinueTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();
@@ -559,6 +683,20 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertEqualsDeep with set failure", expectedExceptions = {AssertionError.class})
     public void testAssertEqualsDeepFailureWithSet() {
+        makeFailedAssertionsBreakTests();
+        TestContext context = new TestContext();
+        StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
+        logMessage.getAssertions().clear();
+        Assert.assertEquals(logMessage.getAssertions().size(), 0);
+
+        Set<String> obj1 = Set.of("v1", "v2", "v3");
+        Set<String> obj2 = Set.of("v4");
+        context.assertEqualsDeep(obj1, obj2, "should be equal");
+    }
+
+    @Test(description = "Test assertEqualsDeep with set failure continue")
+    public void testAssertEqualsDeepFailureWithSetContinue() {
+        makeFailedAssertionsContinueTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();
@@ -615,6 +753,20 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertNotEqualsDeep failure", expectedExceptions = {AssertionError.class})
     public void testAssertNotEqualsDeepFailureWithMap() {
+        makeFailedAssertionsBreakTests();
+        TestContext context = new TestContext();
+        StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
+        logMessage.getAssertions().clear();
+        Assert.assertEquals(logMessage.getAssertions().size(), 0);
+
+        Map<String, String> obj1 = Map.of("k1", "v1", "k2", "v2", "k3", "v3");
+        Map<String, String> obj2 = Map.of("k1", "v1", "k2", "v2", "k3", "v3");
+        context.assertNotEqualsDeep(obj1, obj2, "should not be equal");
+    }
+
+    @Test(description = "Test assertNotEqualsDeep failure continue")
+    public void testAssertNotEqualsDeepFailureWithMapContinue() {
+        makeFailedAssertionsContinueTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();
@@ -671,6 +823,20 @@ public class AssertionContextTest {
 
     @Test(description = "Test assertNotEqualsDeep failure", expectedExceptions = {AssertionError.class})
     public void testAssertNotEqualsDeepFailureWithSet() {
+        makeFailedAssertionsBreakTests();
+        TestContext context = new TestContext();
+        StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
+        logMessage.getAssertions().clear();
+        Assert.assertEquals(logMessage.getAssertions().size(), 0);
+
+        Set<String> obj1 = Set.of("v1", "v2", "v3");
+        Set<String> obj2 = Set.of("v1", "v2", "v3");
+        context.assertNotEqualsDeep(obj1, obj2, "should not be equal");
+    }
+
+    @Test(description = "Test assertNotEqualsDeep failure continue")
+    public void testAssertNotEqualsDeepFailureWithSetContinue() {
+        makeFailedAssertionsContinueTests();
         TestContext context = new TestContext();
         StepInformationLogMessage logMessage = context.getLogCollection().getStepLogOfPendingStep();
         logMessage.getAssertions().clear();


### PR DESCRIPTION
In the configuration file you can define if failed assertions should break the test or if the test should continue