### PR TITLE
Issue/run id testrail via config

### DIFF
--- a/qtaf-core/src/main/resources/qtaf.json
+++ b/qtaf-core/src/main/resources/qtaf.json
@@ -92,7 +92,8 @@
     "authentication": {
       "clientId": null,
       "clientSecret": null
-    }
+    },
+    "runId": null
   },
   "security": {
     "key": null

--- a/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriber.java
+++ b/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriber.java
@@ -180,7 +180,7 @@ public class UploadTestsSubscriber implements IEventSubscriber {
     public String getRunId(TestRail testRailIdAnnotation) {
 
         ConfigMap config = ConfigurationFactory.getInstance();
-        String runId = "no runID";
+        String runId;
 
         if (null != config.getString("testrail.runId")){
             runId = config.getString("testrail.runId");

--- a/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriber.java
+++ b/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriber.java
@@ -132,7 +132,7 @@ public class UploadTestsSubscriber implements IEventSubscriber {
     public void handleScenarioSuccess(TestRail testRailIdAnnotation) {
         Arrays.stream(testRailIdAnnotation.caseId()).forEach(caseId -> {
             try {
-                TestRailManager.addResultForTestCase(client, caseId, testRailIdAnnotation.runId(), 1, "");
+                TestRailManager.addResultForTestCase(client, caseId, getRunId(testRailIdAnnotation), 1, "");
                 QtafFactory.getLogger().info("Results are uploaded to testRail");
                 Attachments attachments = TestRailManager.getAttachmentsForTestCase(client, caseId);
                 if (attachments != null) {
@@ -160,7 +160,7 @@ public class UploadTestsSubscriber implements IEventSubscriber {
                 .orElseThrow(() -> new IllegalStateException("expected at least one failed step"));
         for (String caseId : testRailIdAnnotation.caseId()) {
             try {
-                TestRailManager.addResultForTestCase(client, caseId, testRailIdAnnotation.runId(), 5, "Failure found in: " + errorMessage);
+                TestRailManager.addResultForTestCase(client, caseId, getRunId(testRailIdAnnotation), 5, "Failure found in: " + errorMessage);
                 TestRailManager.addAttachmentForTestCase(client, caseId, QtafFactory.getTestSuiteLogCollection().getLogDirectory() + "/Report.html");
                 TestRailManager.addAttachmentForTestCase(client, caseId, scenarioLog.getScreenshotAfter());
                 QtafFactory.getLogger().info("Results are uploaded to testRail");
@@ -171,7 +171,7 @@ public class UploadTestsSubscriber implements IEventSubscriber {
     }
 
     /**
-     * Rreturns the runId. The runId set in the configuration file is preferred to the runId set in the annotation.
+     * Returns the runId. The runId set in the configuration file is preferred to the runId set in the annotation.
      *
      * @param testRailIdAnnotation the annotation Object
      *
@@ -188,7 +188,7 @@ public class UploadTestsSubscriber implements IEventSubscriber {
         }
 
         if (null == testRailIdAnnotation){
-            throw new IllegalArgumentException("the testRailId annotation is null");
+            throw new NullPointerException("The passed testRailId annotation is null");
         }
 
         if (testRailIdAnnotation.runId().isEmpty()){

--- a/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriber.java
+++ b/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriber.java
@@ -170,19 +170,34 @@ public class UploadTestsSubscriber implements IEventSubscriber {
         }
     }
 
-    public int getRunid(TestRail testRailAnnotation) {
+    /**
+     * Rreturns the runId. The runId set in the configuration file is preferred to the runId set in the annotation.
+     *
+     * @param testRailIdAnnotation the annotation Object
+     *
+     * @return the runId
+     */
+    public String getRunId(TestRail testRailIdAnnotation) {
+
         ConfigMap config = ConfigurationFactory.getInstance();
-        int runId = -1;
-        if (null != config.getInt("testrail.runId")){
-            runId = config.getInt("testrail.runId");
+        String runId = "no runID";
+
+        if (null != config.getString("testrail.runId")){
+            runId = config.getString("testrail.runId");
             return runId;
         }
 
-        // annotierte runId zurückgeben
+        if (null == testRailIdAnnotation){
+            throw new IllegalArgumentException("the testRailId annotation is null");
+        }
 
-        throw new IllegalArgumentException( "No runId could be assigned to the test case. " +
-                                            "The runId must be set either via the configuration file (testrail.runId) " +
-                                            "or via the corresponding annotation.()");
+        if (testRailIdAnnotation.runId().isEmpty()){
+            throw new IllegalArgumentException( "No runId could be assigned to the test case. " +
+                    "The runId must be set either via the configuration file (testrail.runId) " +
+                    "or via the corresponding annotation.(@TestRail)");
+        }
+        runId = testRailIdAnnotation.runId();
+        return runId;
     }
 }
 

--- a/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriber.java
+++ b/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriber.java
@@ -1,6 +1,7 @@
 package de.qytera.qtaf.testrail.event_subscriber;
 
 import de.qytera.qtaf.core.QtafFactory;
+import de.qytera.qtaf.core.config.ConfigurationFactory;
 import de.qytera.qtaf.core.config.entity.ConfigMap;
 import de.qytera.qtaf.core.config.exception.MissingConfigurationValueException;
 import de.qytera.qtaf.core.events.QtafEvents;
@@ -167,6 +168,21 @@ public class UploadTestsSubscriber implements IEventSubscriber {
                 QtafFactory.getLogger().error(e);
             }
         }
+    }
+
+    public int getRunid(TestRail testRailAnnotation) {
+        ConfigMap config = ConfigurationFactory.getInstance();
+        int runId = -1;
+        if (null != config.getInt("testrail.runId")){
+            runId = config.getInt("testrail.runId");
+            return runId;
+        }
+
+        // annotierte runId zurückgeben
+
+        throw new IllegalArgumentException( "No runId could be assigned to the test case. " +
+                                            "The runId must be set either via the configuration file (testrail.runId) " +
+                                            "or via the corresponding annotation.()");
     }
 }
 

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
@@ -45,21 +45,30 @@ public class UploadTestsSubscriberTest {
 
     }
 
-
     @TestRail(caseId = "01", runId = "01")
     public void testDummyRunIdAnnotated(){}
 
     @TestRail(caseId = "01", runId = "")
     public void testDummyRunIdEmptyAnnotation(){}
-    @Test(description = "Test getRunId")
-    public void testGetRunId() throws ClassNotFoundException, NoSuchMethodException {
+
+    @Test(description = "Test getRunId(): no runId given")
+    public void testGetRunIdNoRunIdGiven(){
+        UploadTestsSubscriber subscriber = new UploadTestsSubscriber();
+        Assert.assertThrows(NullPointerException.class, ()->subscriber.getRunId(null));
+    }
+    @Test(description = "Test getRunId(): empty runId given")
+    public void testGetRunIdEmptyRunIdGiven() throws ClassNotFoundException, NoSuchMethodException {
         UploadTestsSubscriber subscriber = new UploadTestsSubscriber();
         Class<?> dummyClass = Class.forName("de.qytera.testrail.event_subscriber.UploadTestsSubscriberTest");
 
-        Assert.assertThrows(NullPointerException.class, ()->subscriber.getRunId(null));
-
         TestRail runIdEmptyAnnotation = dummyClass.getMethod("testDummyRunIdEmptyAnnotation").getAnnotation(TestRail.class);
         Assert.assertThrows(IllegalArgumentException.class, () -> subscriber.getRunId(runIdEmptyAnnotation));
+    }
+
+    @Test(description = "Test getRunId(): correct runId given")
+    public void testGetRunIdCorrectRunIdGiven() throws ClassNotFoundException, NoSuchMethodException {
+        UploadTestsSubscriber subscriber = new UploadTestsSubscriber();
+        Class<?> dummyClass = Class.forName("de.qytera.testrail.event_subscriber.UploadTestsSubscriberTest");
 
         TestRail runIdAnnotatedAnnotation = dummyClass.getMethod("testDummyRunIdAnnotated").getAnnotation(TestRail.class);
         Assert.assertEquals(subscriber.getRunId(runIdAnnotatedAnnotation), "01");

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
@@ -30,6 +30,8 @@ import java.lang.reflect.Method;
 import java.security.GeneralSecurityException;
 import java.util.List;
 
+import java.lang.reflect.*;
+
 /**
  * Testrail upload subscriber tests
  */
@@ -41,6 +43,25 @@ public class UploadTestsSubscriberTest {
         Assert.assertFalse(QtafEvents.logsPersisted.hasObservers());
         subscriber.initialize();
         Assert.assertTrue(QtafEvents.logsPersisted.hasObservers());
+
+    }
+
+
+    @TestRail(caseId = "01", runId = "01")
+    public void testDummyRunIdAnnotated(){}
+
+    @TestRail(caseId = "01", runId = "")
+    public void testDummyRunIdEmptyAnnotation(){}
+    @Test(description = "Test getRunId")
+    public void testGetRunId() throws ClassNotFoundException, NoSuchMethodException {
+        UploadTestsSubscriber subscriber = new UploadTestsSubscriber();
+        Class<?> dummyClass = Class.forName("de.qytera.testrail.event_subscriber.UploadTestsSubscriberTest");
+
+        TestRail runIdAnnotatedAnnotation = dummyClass.getMethod("testDummyRunIdAnnotated").getAnnotation(TestRail.class);
+        Assert.assertEquals(subscriber.getRunId(runIdAnnotatedAnnotation), "01");
+
+        TestRail runIdEmptyAnnotation = dummyClass.getMethod("testDummyRunIdEmptyAnnotation").getAnnotation(TestRail.class);
+        Assert.assertThrows(IllegalArgumentException.class, () -> subscriber.getRunId(runIdEmptyAnnotation));
 
     }
 

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
@@ -56,12 +56,13 @@ public class UploadTestsSubscriberTest {
         UploadTestsSubscriber subscriber = new UploadTestsSubscriber();
         Class<?> dummyClass = Class.forName("de.qytera.testrail.event_subscriber.UploadTestsSubscriberTest");
 
-        TestRail runIdAnnotatedAnnotation = dummyClass.getMethod("testDummyRunIdAnnotated").getAnnotation(TestRail.class);
-        Assert.assertEquals(subscriber.getRunId(runIdAnnotatedAnnotation), "01");
+        Assert.assertThrows(NullPointerException.class, ()->subscriber.getRunId(null));
 
         TestRail runIdEmptyAnnotation = dummyClass.getMethod("testDummyRunIdEmptyAnnotation").getAnnotation(TestRail.class);
         Assert.assertThrows(IllegalArgumentException.class, () -> subscriber.getRunId(runIdEmptyAnnotation));
 
+        TestRail runIdAnnotatedAnnotation = dummyClass.getMethod("testDummyRunIdAnnotated").getAnnotation(TestRail.class);
+        Assert.assertEquals(subscriber.getRunId(runIdAnnotatedAnnotation), "01");
     }
 
     @Test(description = "Test the setup function")

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
@@ -1,6 +1,7 @@
 package de.qytera.testrail.event_subscriber;
 
 import de.qytera.qtaf.core.QtafFactory;
+import de.qytera.qtaf.core.config.ConfigurationFactory;
 import de.qytera.qtaf.core.config.entity.ConfigMap;
 import de.qytera.qtaf.core.config.exception.MissingConfigurationValueException;
 import de.qytera.qtaf.core.events.QtafEvents;
@@ -72,6 +73,22 @@ public class UploadTestsSubscriberTest {
 
         TestRail runIdAnnotatedAnnotation = dummyClass.getMethod("testDummyRunIdAnnotated").getAnnotation(TestRail.class);
         Assert.assertEquals(subscriber.getRunId(runIdAnnotatedAnnotation), "01");
+    }
+
+    @Test(description = "Test getRunId(): correct runId given but overwritten by config")
+    public void testGetRunIdCorrectRunIdGivenButOverwritenByConfig() throws ClassNotFoundException, NoSuchMethodException {
+        UploadTestsSubscriber subscriber = new UploadTestsSubscriber();
+        Class<?> dummyClass = Class.forName("de.qytera.testrail.event_subscriber.UploadTestsSubscriberTest");
+
+        ConfigMap config = ConfigurationFactory.getInstance();
+        String predefinedRunId = config.getString("testrail.runId");
+        config.setString("testrail.runId", "212");
+
+        TestRail runIdAnnotatedAnnotation = dummyClass.getMethod("testDummyRunIdAnnotated").getAnnotation(TestRail.class);
+        Assert.assertEquals(subscriber.getRunId(runIdAnnotatedAnnotation), "212");
+
+        // Reset runId
+        config.setString("testrail.runId", predefinedRunId);
     }
 
     @Test(description = "Test the setup function")

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
@@ -30,7 +30,6 @@ import java.lang.reflect.Method;
 import java.security.GeneralSecurityException;
 import java.util.List;
 
-import java.lang.reflect.*;
 
 /**
  * Testrail upload subscriber tests


### PR DESCRIPTION
Added getRunId() which implements the behavior that the runId set in the config-file is taken into account and is preferred to the runId set in the annotation.