### PR TITLE
Fix broken TestRail screenshot upload

### DIFF
--- a/qtaf-http/src/main/java/de/qytera/qtaf/http/WebService.java
+++ b/qtaf-http/src/main/java/de/qytera/qtaf/http/WebService.java
@@ -9,6 +9,7 @@ import jakarta.ws.rs.core.Response;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.glassfish.jersey.gson.internal.JsonGsonProvider;
+import org.glassfish.jersey.media.multipart.MultiPartFeature;
 
 import java.net.URI;
 
@@ -31,7 +32,9 @@ public final class WebService {
     /**
      * Jersey HTTP Client.
      */
-    private static final Client CLIENT = ClientBuilder.newClient().register(JsonGsonProvider.class);
+    private static final Client CLIENT = ClientBuilder.newClient()
+            .register(JsonGsonProvider.class)
+            .register(MultiPartFeature.class);
 
     /**
      * Maximum number of retries in case an HTTP request fails because of networking issues.

--- a/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriber.java
+++ b/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriber.java
@@ -162,7 +162,17 @@ public class UploadTestsSubscriber implements IEventSubscriber {
             try {
                 TestRailManager.addResultForTestCase(client, caseId, getRunId(testRailIdAnnotation), 5, "Failure found in: " + errorMessage);
                 TestRailManager.addAttachmentForTestCase(client, caseId, QtafFactory.getTestSuiteLogCollection().getLogDirectory() + "/Report.html");
-                TestRailManager.addAttachmentForTestCase(client, caseId, scenarioLog.getScreenshotAfter());
+                for (StepInformationLogMessage step : scenarioLog.getLogMessages(StepInformationLogMessage.class)) {
+                    if (!step.getScreenshotBefore().isBlank()) {
+                        TestRailManager.addAttachmentForTestCase(client, caseId, step.getScreenshotBefore());
+                    }
+                    if (!step.getScreenshotAfter().isBlank()) {
+                        TestRailManager.addAttachmentForTestCase(client, caseId, step.getScreenshotAfter());
+                    }
+                }
+                for (String filepath : scenarioLog.getScreenshotPaths()) {
+                    TestRailManager.addAttachmentForTestCase(client, caseId, filepath);
+                }
                 QtafFactory.getLogger().info("Results are uploaded to testRail");
             } catch (Exception e) {
                 QtafFactory.getLogger().error(e);

--- a/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriber.java
+++ b/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriber.java
@@ -21,6 +21,7 @@ import de.qytera.qtaf.testrail.utils.TestRailManager;
 import lombok.Data;
 import rx.Subscription;
 
+import java.nio.file.Path;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -118,6 +119,21 @@ public class UploadTestsSubscriber implements IEventSubscriber {
         }
         TestRail testRailIdAnnotation = scenarioLog.getAnnotation(TestRail.class);
         if (testRailIdAnnotation != null) {
+            Arrays.stream(testRailIdAnnotation.caseId()).forEach(caseId -> {
+                try {
+                    Attachments attachments = TestRailManager.getAttachmentsForTestCase(client, caseId);
+                    if (attachments != null) {
+                        for (Attachment attachment : attachments.getAttachments()) {
+                            TestRailManager.deleteAttachmentForTestCase(client, attachment.getId());
+                        }
+                    }
+                } catch (Exception e) {
+                    QtafFactory.getLogger().error(
+                            "[QTAF TestRail Plugin] Failed to delete attachments of case %s".formatted(caseId)
+                    );
+                    QtafFactory.getLogger().error(e);
+                }
+            });
             if (scenarioLog.getStatus().equals(TestScenarioLogCollection.Status.FAILURE)) {
                 handleScenarioFailure(scenarioLog, testRailIdAnnotation);
             } else if (scenarioLog.getStatus().equals(TestScenarioLogCollection.Status.SUCCESS)) {
@@ -136,12 +152,6 @@ public class UploadTestsSubscriber implements IEventSubscriber {
             try {
                 TestRailManager.addResultForTestCase(client, caseId, getRunId(testRailIdAnnotation), 1, "");
                 QtafFactory.getLogger().info("Results are uploaded to testRail");
-                Attachments attachments = TestRailManager.getAttachmentsForTestCase(client, caseId);
-                if (attachments != null) {
-                    for (Attachment attachment : attachments.getAttachments()) {
-                        TestRailManager.deleteAttachmentForTestCase(client, attachment.getId());
-                    }
-                }
             } catch (Exception e) {
                 QtafFactory.getLogger().error(e);
             }
@@ -164,17 +174,17 @@ public class UploadTestsSubscriber implements IEventSubscriber {
             try {
                 TestRailManager.addResultForTestCase(client, caseId, getRunId(testRailIdAnnotation), 5, "Failure found in: " + errorMessage);
                 TestRailManager.addAttachmentForTestCase(client, caseId, QtafFactory.getTestSuiteLogCollection().getLogDirectory() + "/Report.html");
-                Set<String> screenshots = new HashSet<>();
-                screenshots.add(scenarioLog.getScreenshotBefore());
-                for (StepInformationLogMessage step : scenarioLog.getLogMessages(StepInformationLogMessage.class)) {
-                    screenshots.add(step.getScreenshotBefore());
-                    screenshots.add(step.getScreenshotAfter());
+                Set<Path> attachmentPaths = new HashSet<>();
+                for (String screenshotPath : scenarioLog.getScreenshotPaths()) {
+                    attachmentPaths.add(Path.of(screenshotPath).toAbsolutePath());
                 }
-                screenshots.add(scenarioLog.getScreenshotAfter());
-                screenshots.addAll(scenarioLog.getScreenshotPaths());
-                for (String screenshot : screenshots) {
-                    if (!screenshot.isBlank()) {
-                        TestRailManager.addAttachmentForTestCase(client, caseId, screenshot);
+                for (StepInformationLogMessage step : scenarioLog.getLogMessages(StepInformationLogMessage.class)) {
+                    attachmentPaths.add(Path.of(step.getScreenshotBefore()).toAbsolutePath());
+                    attachmentPaths.add(Path.of(step.getScreenshotAfter()).toAbsolutePath());
+                }
+                for (Path path : attachmentPaths) {
+                    if (path.toFile().isFile()) {
+                        TestRailManager.addAttachmentForTestCase(client, caseId, path.toString());
                     }
                 }
                 QtafFactory.getLogger().info("Results are uploaded to testRail");

--- a/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/utils/APIUtil.java
+++ b/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/utils/APIUtil.java
@@ -1,0 +1,45 @@
+package de.qytera.qtaf.testrail.utils;
+
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPart;
+import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
+
+import java.io.File;
+import java.io.IOException;
+import java.text.ParseException;
+
+/**
+ * Utility class for handling TestRail multipart attachments.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class APIUtil {
+
+    /**
+     * Converts a file into a multipart attachment entity, ready to be sent to TestRail's API.
+     *
+     * @param filePath the file to attach
+     * @return the request entity
+     * @throws ParseException if the file cannot be processed
+     * @throws IOException    if the multipart entity cannot be constructed
+     * @see <a href="https://support.testrail.com/hc/en-us/articles/7077039051284#example-attachment-upload-0-3">TestRail documentation</a>
+     */
+    public static Entity<MultiPart> toMultipartAttachment(String filePath) throws ParseException, IOException {
+        try (MultiPart multiPartEntity = new FormDataMultiPart()) {
+            FileDataBodyPart filePart = new FileDataBodyPart("attachment", new File(filePath));
+            // Testrail only accepts content-dispositions of the following form:
+            // Content-Disposition: form-data; name="attachment"; filename="..."
+            // See: https://github.com/gurock/testrail-api/blob/0320205d86f223415db3e8a301b9a534202ff820/java/com/gurock/testrail/APIClient.java#L166
+            filePart.setFormDataContentDisposition(new FormDataContentDisposition(
+                    "form-data; name=\"attachment\"; filename=\"%s\"".formatted(filePart.getFileEntity().getName()))
+            );
+            multiPartEntity.bodyPart(filePart);
+            return Entity.entity(multiPartEntity, MediaType.MULTIPART_FORM_DATA);
+        }
+    }
+
+}

--- a/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/utils/TestRailManager.java
+++ b/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/utils/TestRailManager.java
@@ -3,23 +3,25 @@ package de.qytera.qtaf.testrail.utils;
 import com.google.common.net.HttpHeaders;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
+import de.qytera.qtaf.core.QtafFactory;
 import de.qytera.qtaf.core.gson.GsonFactory;
 import de.qytera.qtaf.http.RequestBuilder;
 import de.qytera.qtaf.http.WebService;
 import de.qytera.qtaf.testrail.entity.Attachments;
 import jakarta.ws.rs.client.Entity;
-import jakarta.ws.rs.core.EntityPart;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.glassfish.jersey.media.multipart.FormDataMultiPart;
+import org.glassfish.jersey.media.multipart.MultiPart;
+import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
+import java.text.ParseException;
 
 /**
  * A manager class for keeping track of and uploading executed tests.
@@ -60,19 +62,28 @@ public class TestRailManager {
      * @throws IOException  if the file cannot be accessed
      */
     public static void addAttachmentForTestCase(APIClient client, String testCaseId, String path) throws APIException, IOException {
-        File file = new File(path);
-        List<EntityPart> parts = new ArrayList<>();
-        parts.add(EntityPart.withName("attachment")
-                .fileName(file.getName())
-                .content(new FileInputStream(file))
-                .build());
-        RequestBuilder request = WebService.buildRequest(URI.create(client.getUrl() + "add_attachment_to_case/" + testCaseId));
-        request.getBuilder().header(HttpHeaders.AUTHORIZATION, client.getAuthorizationHeader());
-        try (Response response = WebService.post(request, Entity.entity(parts, MediaType.MULTIPART_FORM_DATA))) {
-            if (response.getStatus() != Response.Status.OK.getStatusCode()) {
-                String content = response.readEntity(String.class);
-                throw new APIException(response.getStatus(), content);
+        try (MultiPart multiPartEntity = new FormDataMultiPart()) {
+            FileDataBodyPart filePart = new FileDataBodyPart("attachment", new File(path));
+            // Testrail only accepts content-dispositions of the following form:
+            // Content-Disposition: form-data; name="attachment"; filename="..."
+            // See: https://github.com/gurock/testrail-api/blob/0320205d86f223415db3e8a301b9a534202ff820/java/com/gurock/testrail/APIClient.java#L166
+            filePart.setFormDataContentDisposition(new FormDataContentDisposition(
+                    "form-data; name=\"attachment\"; filename=\"%s\"".formatted(filePart.getFileEntity().getName()))
+            );
+            multiPartEntity.bodyPart(filePart);
+            RequestBuilder request = WebService.buildRequest(
+                    URI.create("%s/add_attachment_to_case/%s".formatted(client.getUrl(), testCaseId))
+            );
+            request.getBuilder().header(HttpHeaders.AUTHORIZATION, client.getAuthorizationHeader());
+            try (Response response = WebService.post(request, Entity.entity(multiPartEntity, MediaType.MULTIPART_FORM_DATA))) {
+                if (response.getStatus() != Response.Status.OK.getStatusCode()) {
+                    String content = response.readEntity(String.class);
+                    throw new APIException(response.getStatus(), content);
+                }
             }
+        } catch (ParseException e) {
+            QtafFactory.getLogger().error("[QTAF TestRail Plugin] Failed to read attachment: %s", path);
+            QtafFactory.getLogger().error(e);
         }
     }
 

--- a/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/utils/TestRailManager.java
+++ b/qtaf-testrail-plugin/src/main/java/de/qytera/qtaf/testrail/utils/TestRailManager.java
@@ -13,12 +13,8 @@ import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPart;
-import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.text.ParseException;
@@ -62,15 +58,8 @@ public class TestRailManager {
      * @throws IOException  if the file cannot be accessed
      */
     public static void addAttachmentForTestCase(APIClient client, String testCaseId, String path) throws APIException, IOException {
-        try (MultiPart multiPartEntity = new FormDataMultiPart()) {
-            FileDataBodyPart filePart = new FileDataBodyPart("attachment", new File(path));
-            // Testrail only accepts content-dispositions of the following form:
-            // Content-Disposition: form-data; name="attachment"; filename="..."
-            // See: https://github.com/gurock/testrail-api/blob/0320205d86f223415db3e8a301b9a534202ff820/java/com/gurock/testrail/APIClient.java#L166
-            filePart.setFormDataContentDisposition(new FormDataContentDisposition(
-                    "form-data; name=\"attachment\"; filename=\"%s\"".formatted(filePart.getFileEntity().getName()))
-            );
-            multiPartEntity.bodyPart(filePart);
+        try {
+            Entity<MultiPart> multiPartEntity = APIUtil.toMultipartAttachment(path);
             RequestBuilder request = WebService.buildRequest(
                     URI.create("%s/add_attachment_to_case/%s".formatted(client.getUrl(), testCaseId))
             );

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriberTest.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/qtaf/testrail/event_subscriber/UploadTestsSubscriberTest.java
@@ -1,4 +1,4 @@
-package de.qytera.testrail.event_subscriber;
+package de.qytera.qtaf.testrail.event_subscriber;
 
 import de.qytera.qtaf.core.QtafFactory;
 import de.qytera.qtaf.core.config.ConfigurationFactory;
@@ -16,7 +16,6 @@ import de.qytera.qtaf.testrail.config.TestRailConfigHelper;
 import de.qytera.qtaf.testrail.entity.Attachment;
 import de.qytera.qtaf.testrail.entity.Attachments;
 import de.qytera.qtaf.testrail.entity.Link;
-import de.qytera.qtaf.testrail.event_subscriber.UploadTestsSubscriber;
 import de.qytera.qtaf.testrail.utils.APIClient;
 import de.qytera.qtaf.testrail.utils.TestRailManager;
 import org.mockito.MockedStatic;
@@ -63,7 +62,7 @@ public class UploadTestsSubscriberTest {
     @Test(description = "Test getRunId(): empty runId given")
     public void testGetRunIdEmptyRunIdGiven() throws ClassNotFoundException, NoSuchMethodException {
         UploadTestsSubscriber subscriber = new UploadTestsSubscriber();
-        Class<?> dummyClass = Class.forName("de.qytera.testrail.event_subscriber.UploadTestsSubscriberTest");
+        Class<?> dummyClass = Class.forName("de.qytera.qtaf.testrail.event_subscriber.UploadTestsSubscriberTest");
 
         TestRail runIdEmptyAnnotation = dummyClass.getMethod("testDummyRunIdEmptyAnnotation").getAnnotation(TestRail.class);
         Assert.assertThrows(IllegalArgumentException.class, () -> subscriber.getRunId(runIdEmptyAnnotation));
@@ -72,7 +71,7 @@ public class UploadTestsSubscriberTest {
     @Test(description = "Test getRunId(): correct runId given")
     public void testGetRunIdCorrectRunIdGiven() throws ClassNotFoundException, NoSuchMethodException {
         UploadTestsSubscriber subscriber = new UploadTestsSubscriber();
-        Class<?> dummyClass = Class.forName("de.qytera.testrail.event_subscriber.UploadTestsSubscriberTest");
+        Class<?> dummyClass = Class.forName("de.qytera.qtaf.testrail.event_subscriber.UploadTestsSubscriberTest");
 
         TestRail runIdAnnotatedAnnotation = dummyClass.getMethod("testDummyRunIdAnnotated").getAnnotation(TestRail.class);
         Assert.assertEquals(subscriber.getRunId(runIdAnnotatedAnnotation), "01");
@@ -81,7 +80,7 @@ public class UploadTestsSubscriberTest {
     @Test(description = "Test getRunId(): correct runId given but overwritten by config")
     public void testGetRunIdCorrectRunIdGivenButOverwritenByConfig() throws ClassNotFoundException, NoSuchMethodException {
         UploadTestsSubscriber subscriber = new UploadTestsSubscriber();
-        Class<?> dummyClass = Class.forName("de.qytera.testrail.event_subscriber.UploadTestsSubscriberTest");
+        Class<?> dummyClass = Class.forName("de.qytera.qtaf.testrail.event_subscriber.UploadTestsSubscriberTest");
 
         ConfigMap config = ConfigurationFactory.getInstance();
         String predefinedRunId = config.getString("testrail.runId");
@@ -432,16 +431,6 @@ public class UploadTestsSubscriberTest {
                     () -> TestRailManager.addResultForTestCase(Mockito.any(APIClient.class), Mockito.anyString(), Mockito.anyString(), Mockito.anyInt(), Mockito.anyString()),
                     Mockito.times(1)
             );
-
-            manager.verify(
-                    () -> TestRailManager.deleteAttachmentForTestCase(Mockito.any(APIClient.class), Mockito.anyString()),
-                    Mockito.times(1)
-            );
-
-            manager.verify(
-                    () -> TestRailManager.getAttachmentsForTestCase(Mockito.any(APIClient.class), Mockito.anyString()),
-                    Mockito.times(1)
-            );
         }
     }
 
@@ -511,24 +500,23 @@ public class UploadTestsSubscriberTest {
             );
             StepInformationLogMessage step = new StepInformationLogMessage("foo.bar", "message");
             step.setStatus(StepInformationLogMessage.Status.ERROR);
-            step.setScreenshotBefore("before.png");
-            step.setScreenshotAfter("after.png");
+            step.setScreenshotBefore("nonexistent.png");
+            step.setScreenshotAfter(".gitignore");
             scenario1.addLogMessage(step);
-            scenario1.setScreenshotBefore("beforeScenario.png");
-            scenario1.setScreenshotAfter("afterScenario.png");
+            scenario1.setScreenshotBefore(".\\pom.xml");
+            scenario1.setScreenshotAfter(".gitignore");
+            scenario1.addScreenshotPath("./pom.xml");
 
             // Call subscriber method
             subscriber.handleScenarioFailure(scenario1, testRailAnnotation);
 
             // Check how many times manager methods were called:
             // - once for the HTML report
-            // - once the screenshot before the scenario
-            // - once the screenshot after the scenario
-            // - once the screenshot before the step
-            // - once the screenshot after the step
+            // - once for .gitignore
+            // - once the pom.xml
             manager.verify(
                     () -> TestRailManager.addAttachmentForTestCase(Mockito.any(APIClient.class), Mockito.anyString(), Mockito.anyString()),
-                    Mockito.times(5)
+                    Mockito.times(3)
             );
 
             manager.verify(

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/qtaf/testrail/utils/APIUtilTest.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/qtaf/testrail/utils/APIUtilTest.java
@@ -1,0 +1,48 @@
+package de.qytera.qtaf.testrail.utils;
+
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.core.MediaType;
+import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
+import org.glassfish.jersey.media.multipart.MultiPart;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.text.ParseException;
+
+public class APIUtilTest {
+
+    @Test
+    public void testToMultipartAttachmentMediaType() throws ParseException, IOException {
+        Entity<MultiPart> entity = APIUtil.toMultipartAttachment("pom.xml");
+        Assert.assertEquals(entity.getMediaType(), MediaType.MULTIPART_FORM_DATA_TYPE);
+    }
+
+    @Test
+    public void testToMultipartAttachmentBodyPartSize() throws ParseException, IOException {
+        Entity<MultiPart> entity = APIUtil.toMultipartAttachment("pom.xml");
+        Assert.assertEquals(entity.getEntity().getBodyParts().size(), 1);
+    }
+
+    @Test
+    public void testToMultipartAttachmentBodyPartContentDisposition() throws ParseException, IOException {
+        Entity<MultiPart> entity = APIUtil.toMultipartAttachment("pom.xml");
+        Assert.assertEquals(entity.getEntity().getBodyParts().get(0).getContentDisposition().getClass(), FormDataContentDisposition.class);
+        if (entity.getEntity().getBodyParts().get(0).getContentDisposition() instanceof FormDataContentDisposition contentDisposition) {
+            Assert.assertEquals(contentDisposition.getType(), "form-data");
+            Assert.assertEquals(contentDisposition.getFileName(), "pom.xml");
+            Assert.assertEquals(contentDisposition.getName(), "attachment");
+            Assert.assertNull(contentDisposition.getCreationDate());
+            Assert.assertNull(contentDisposition.getReadDate());
+            Assert.assertNull(contentDisposition.getModificationDate());
+            Assert.assertEquals(contentDisposition.getSize(), -1);
+        } else {
+            Assert.fail(
+                    "Expected the attachment's content disposition to be an instance of %s, but it is: %s".formatted(
+                            FormDataContentDisposition.class,
+                            entity.getEntity().getBodyParts().get(0).getContentDisposition().getClass()
+                    )
+            );
+        }
+    }
+}

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/qtaf/testrail/utils/APIUtilTest.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/qtaf/testrail/utils/APIUtilTest.java
@@ -1,48 +1,46 @@
 package de.qytera.qtaf.testrail.utils;
 
-import jakarta.ws.rs.client.Entity;
 import jakarta.ws.rs.core.MediaType;
 import org.glassfish.jersey.media.multipart.FormDataContentDisposition;
-import org.glassfish.jersey.media.multipart.MultiPart;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
 import java.text.ParseException;
 
 public class APIUtilTest {
 
     @Test
-    public void testToMultipartAttachmentMediaType() throws ParseException, IOException {
-        Entity<MultiPart> entity = APIUtil.toMultipartAttachment("pom.xml");
-        Assert.assertEquals(entity.getMediaType(), MediaType.MULTIPART_FORM_DATA_TYPE);
+    public void testToMultipartAttachmentMediaType() throws ParseException {
+        APIUtil.consumeAttachment("pom.xml", entity ->
+                Assert.assertEquals(entity.getMediaType(), MediaType.MULTIPART_FORM_DATA_TYPE)
+        );
     }
 
     @Test
-    public void testToMultipartAttachmentBodyPartSize() throws ParseException, IOException {
-        Entity<MultiPart> entity = APIUtil.toMultipartAttachment("pom.xml");
-        Assert.assertEquals(entity.getEntity().getBodyParts().size(), 1);
+    public void testToMultipartAttachmentBodyPartSize() throws ParseException {
+        APIUtil.consumeAttachment("pom.xml", entity -> Assert.assertEquals(entity.getEntity().getBodyParts().size(), 1));
     }
 
     @Test
-    public void testToMultipartAttachmentBodyPartContentDisposition() throws ParseException, IOException {
-        Entity<MultiPart> entity = APIUtil.toMultipartAttachment("pom.xml");
-        Assert.assertEquals(entity.getEntity().getBodyParts().get(0).getContentDisposition().getClass(), FormDataContentDisposition.class);
-        if (entity.getEntity().getBodyParts().get(0).getContentDisposition() instanceof FormDataContentDisposition contentDisposition) {
-            Assert.assertEquals(contentDisposition.getType(), "form-data");
-            Assert.assertEquals(contentDisposition.getFileName(), "pom.xml");
-            Assert.assertEquals(contentDisposition.getName(), "attachment");
-            Assert.assertNull(contentDisposition.getCreationDate());
-            Assert.assertNull(contentDisposition.getReadDate());
-            Assert.assertNull(contentDisposition.getModificationDate());
-            Assert.assertEquals(contentDisposition.getSize(), -1);
-        } else {
-            Assert.fail(
-                    "Expected the attachment's content disposition to be an instance of %s, but it is: %s".formatted(
-                            FormDataContentDisposition.class,
-                            entity.getEntity().getBodyParts().get(0).getContentDisposition().getClass()
-                    )
-            );
-        }
+    public void testToMultipartAttachmentBodyPartContentDisposition() throws ParseException {
+        APIUtil.consumeAttachment("pom.xml", entity -> {
+            Assert.assertEquals(entity.getEntity().getBodyParts().get(0).getContentDisposition().getClass(), FormDataContentDisposition.class);
+            if (entity.getEntity().getBodyParts().get(0).getContentDisposition() instanceof FormDataContentDisposition contentDisposition) {
+                Assert.assertEquals(contentDisposition.getType(), "form-data");
+                Assert.assertEquals(contentDisposition.getFileName(), "pom.xml");
+                Assert.assertEquals(contentDisposition.getName(), "attachment");
+                Assert.assertNull(contentDisposition.getCreationDate());
+                Assert.assertNull(contentDisposition.getReadDate());
+                Assert.assertNull(contentDisposition.getModificationDate());
+                Assert.assertEquals(contentDisposition.getSize(), -1);
+            } else {
+                Assert.fail(
+                        "Expected the attachment's content disposition to be an instance of %s, but it is: %s".formatted(
+                                FormDataContentDisposition.class,
+                                entity.getEntity().getBodyParts().get(0).getContentDisposition().getClass()
+                        )
+                );
+            }
+        });
     }
 }

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/qtaf/testrail/utils/ApiClientTest.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/qtaf/testrail/utils/ApiClientTest.java
@@ -1,6 +1,5 @@
-package de.qytera.testrail.utils;
+package de.qytera.qtaf.testrail.utils;
 
-import de.qytera.qtaf.testrail.utils.APIClient;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/qtaf/testrail/utils/Mocking.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/qtaf/testrail/utils/Mocking.java
@@ -1,4 +1,4 @@
-package de.qytera.testrail.util;
+package de.qytera.qtaf.testrail.utils;
 
 import jakarta.ws.rs.core.Response;
 import org.mockito.AdditionalAnswers;

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/qtaf/testrail/utils/TestRailManagerTest.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/qtaf/testrail/utils/TestRailManagerTest.java
@@ -1,21 +1,16 @@
-package de.qytera.testrail.utils;
+package de.qytera.qtaf.testrail.utils;
 
 import de.qytera.qtaf.core.gson.GsonFactory;
 import de.qytera.qtaf.http.WebService;
 import de.qytera.qtaf.testrail.entity.Attachment;
 import de.qytera.qtaf.testrail.entity.Attachments;
 import de.qytera.qtaf.testrail.entity.Link;
-import de.qytera.qtaf.testrail.utils.APIClient;
-import de.qytera.qtaf.testrail.utils.APIException;
-import de.qytera.qtaf.testrail.utils.TestRailManager;
-import de.qytera.testrail.util.Mocking;
 import jakarta.ws.rs.core.Response;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
 import java.util.List;
 
 public class TestRailManagerTest {
@@ -46,18 +41,21 @@ public class TestRailManagerTest {
     }
 
     @Test(description = "Test add attachment for test case")
-    public void testAddAttachmentForTestCase() throws APIException, IOException {
+    public void testAddAttachmentForTestCase() {
         APIClient client = new APIClient("https://example.org");
+        Response response = Mocking.simulateInbound(
+                Response.ok().entity(GsonFactory.getInstance().toJson("abcdef-12342-535363")).build()
+        );
         try (MockedStatic<WebService> webService = Mockito.mockStatic(WebService.class)) {
             webService.when(() -> WebService.buildRequest(Mockito.any())).thenCallRealMethod();
-            webService.when(() -> WebService.post(Mockito.any(), Mockito.any()).close()).thenReturn(Response.ok().build());
+            webService.when(() -> WebService.post(Mockito.any(), Mockito.any()).close()).thenReturn(response);
             // Assert that it does not throw.
             TestRailManager.addAttachmentForTestCase(client, "c1", "pom.xml");
         }
     }
 
     @Test(description = "Test add attachment for test case with bad response")
-    public void testAddAttachmentForTestCaseBadResponse() throws IOException {
+    public void testAddAttachmentForTestCaseBadResponse() {
         APIClient client = new APIClient("https://example.org");
         Response response = Mocking.simulateInbound(
                 Response.serverError().entity(GsonFactory.getInstance().toJson("things are going down")).build()
@@ -66,8 +64,6 @@ public class TestRailManagerTest {
             webService.when(() -> WebService.buildRequest(Mockito.any())).thenCallRealMethod();
             webService.when(() -> WebService.post(Mockito.any(), Mockito.any()).close()).thenReturn(response);
             TestRailManager.addAttachmentForTestCase(client, "c1", "pom.xml");
-        } catch (APIException e) {
-            Assert.assertEquals(e.getMessage(), "TestRail API returned HTTP 500 (\"things are going down\")");
         }
     }
 

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
@@ -511,6 +511,7 @@ public class UploadTestsSubscriberTest {
             );
             StepInformationLogMessage step = new StepInformationLogMessage("foo.bar", "message");
             step.setStatus(StepInformationLogMessage.Status.ERROR);
+            step.setScreenshotAfter("after.png");
             scenario1.addLogMessage(step);
 
             // Call subscriber method

--- a/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
+++ b/qtaf-testrail-plugin/src/test/java/de/qytera/testrail/event_subscriber/UploadTestsSubscriberTest.java
@@ -511,16 +511,24 @@ public class UploadTestsSubscriberTest {
             );
             StepInformationLogMessage step = new StepInformationLogMessage("foo.bar", "message");
             step.setStatus(StepInformationLogMessage.Status.ERROR);
+            step.setScreenshotBefore("before.png");
             step.setScreenshotAfter("after.png");
             scenario1.addLogMessage(step);
+            scenario1.setScreenshotBefore("beforeScenario.png");
+            scenario1.setScreenshotAfter("afterScenario.png");
 
             // Call subscriber method
             subscriber.handleScenarioFailure(scenario1, testRailAnnotation);
 
-            // Check how many times manager methods were called
+            // Check how many times manager methods were called:
+            // - once for the HTML report
+            // - once the screenshot before the scenario
+            // - once the screenshot after the scenario
+            // - once the screenshot before the step
+            // - once the screenshot after the step
             manager.verify(
                     () -> TestRailManager.addAttachmentForTestCase(Mockito.any(APIClient.class), Mockito.anyString(), Mockito.anyString()),
-                    Mockito.times(2)
+                    Mockito.times(5)
             );
 
             manager.verify(


### PR DESCRIPTION
Addresses #191. This PR fixes the attachment upload to TestRail, which previously did not work because of superfluous multipart form headers which TestRail's Apache server did not understand.

It also makes the TestRail plugin upload step screenshots in addition to scenario screenshots. These are currently not being uploaded.