### PR TITLE
feat(qtaf-logging)!: improve console log messages

### DIFF
--- a/qtaf-core/pom.xml
+++ b/qtaf-core/pom.xml
@@ -46,12 +46,13 @@
         <log4JVersion>2.21.1</log4JVersion>
         <jsonSimpleVersion>1.1.1</jsonSimpleVersion>
         <jsonPathVersion>2.9.0</jsonPathVersion>
+        <mockitoVersion>5.6.0</mockitoVersion>
         <pebbleVersion>3.2.1</pebbleVersion>
         <reflectionsVersion>0.10.2</reflectionsVersion>
         <rxJavaVersion>1.3.8</rxJavaVersion>
         <seleneideVersion>7.0.4</seleneideVersion>
         <seleniumJavaVersion>4.13.0</seleniumJavaVersion>
-        <slf4jVersion>2.0.9</slf4jVersion>
+        <slf4jVersion>2.0.11</slf4jVersion>
         <testNGCucumberVersion>7.14.0</testNGCucumberVersion>
         <testNGVersion>7.8.0</testNGVersion>
         <webDriverManagerVersion>5.7.0</webDriverManagerVersion>
@@ -155,6 +156,14 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>${jsonPathVersion}</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/org.mockito/mockito-core -->
+        <!-- Mocking library -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>${mockitoVersion}</version>
+            <scope>test</scope>
         </dependency>
         <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-lang3 -->
         <!-- String helper library -->

--- a/qtaf-core/pom.xml
+++ b/qtaf-core/pom.xml
@@ -225,6 +225,5 @@
             <version>${project.parent.version}</version>
             <scope>compile</scope>
         </dependency>
-
     </dependencies>
 </project>

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/config/helper/QtafTestExecutionConfigHelper.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/config/helper/QtafTestExecutionConfigHelper.java
@@ -60,6 +60,6 @@ public class QtafTestExecutionConfigHelper {
      */
     public static boolean isStepLoggingEnabled() {
         ConfigMap config = QtafFactory.getConfiguration();
-        return config.getBoolean(LOGGING_LOG_STEPS);
+        return config.getBoolean(LOGGING_LOG_STEPS, false);
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/config/helper/QtafTestExecutionConfigHelper.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/config/helper/QtafTestExecutionConfigHelper.java
@@ -20,6 +20,10 @@ public class QtafTestExecutionConfigHelper {
 
     private static final String TEST_GROUPS = "tests.groups";
     private static final String TEST_ASSERTION_BEHAVIOUR_ON_FAILURE = "tests.continueOnAssertionFailure";
+    /**
+     * Flag for toggling step logging on or off.
+     */
+    public static final String LOGGING_LOG_STEPS = "logging.logSteps";
 
     /**
      * Get all groups that should run.
@@ -45,5 +49,17 @@ public class QtafTestExecutionConfigHelper {
      */
     public static boolean continueOnAssertionFailure() {
         return config.getBoolean(TEST_ASSERTION_BEHAVIOUR_ON_FAILURE);
+    }
+
+
+    /**
+     * QTAF users have the option to configure if the test steps should get logged to the console. This is useful if
+     * the user wants shorter logs.
+     *
+     * @return true if step logging is wanted and false if logging is unwanted
+     */
+    public static boolean isStepLoggingEnabled() {
+        ConfigMap config = QtafFactory.getConfiguration();
+        return config.getBoolean(LOGGING_LOG_STEPS);
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/event_subscriber/step/StepLoggerSubscriber.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/event_subscriber/step/StepLoggerSubscriber.java
@@ -1,6 +1,7 @@
 package de.qytera.qtaf.core.event_subscriber.step;
 
 import de.qytera.qtaf.core.QtafFactory;
+import de.qytera.qtaf.core.config.entity.ConfigMap;
 import de.qytera.qtaf.core.console.ConsoleColors;
 import de.qytera.qtaf.core.context.IQtafTestContext;
 import de.qytera.qtaf.core.events.QtafEvents;
@@ -278,39 +279,55 @@ public class StepLoggerSubscriber implements IEventSubscriber {
      * @param message           log message
      */
     private void log(StepExecutionInfo stepExecutionInfo, String message) {
-        String assertionMessage = "[Step] [%s] [%s] %s: %s";
-        String stepMessage = "[Step] [%s] [%s] %s";
+        if (checkIfStepLoggingIsConfigured()){
+            String assertionMessage = "[Step] [%s] [%s] %s: %s";
+            String stepMessage = "[Step] [%s] [%s] %s";
 
-        logger.info(
-                stepMessage.formatted(
-                        stepExecutionInfo.getId(),
-                        stepExecutionInfo.getAnnotation().name(),
-                        message
-                )
-        );
+            logger.info(
+                    stepMessage.formatted(
+                            stepExecutionInfo.getId(),
+                            stepExecutionInfo.getAnnotation().name(),
+                            message
+                    )
+            );
 
-        if (stepExecutionInfo.getLogMessage() != null) {
-            for (AssertionLogMessage m : stepExecutionInfo.getLogMessage().getAssertions()) {
-                if (m.hasFailed()) {
-                    logger.info(
-                            assertionMessage.formatted(
-                                    stepExecutionInfo.getId(),
-                                    m.type(),
-                                    ConsoleColors.red("failed"),
-                                    m.getMessage()
-                            )
-                    );
-                } else {
-                    logger.info(
-                            assertionMessage.formatted(
-                                    stepExecutionInfo.getId(),
-                                    m.type(),
-                                    ConsoleColors.green("passed"),
-                                    m.getMessage()
-                            )
-                    );
+            if (stepExecutionInfo.getLogMessage() != null) {
+                for (AssertionLogMessage m : stepExecutionInfo.getLogMessage().getAssertions()) {
+                    if (m.hasFailed()) {
+                        logger.info(
+                                assertionMessage.formatted(
+                                        stepExecutionInfo.getId(),
+                                        m.type(),
+                                        ConsoleColors.red("failed"),
+                                        m.getMessage()
+                                )
+                        );
+                    } else {
+                        logger.info(
+                                assertionMessage.formatted(
+                                        stepExecutionInfo.getId(),
+                                        m.type(),
+                                        ConsoleColors.green("passed"),
+                                        m.getMessage()
+                                )
+                        );
+                    }
                 }
             }
         }
+    }
+
+    /**
+     * The QTAF-User has the option to configure
+     * if the test steps should get logged to the console.
+     * If in the qtaf.json the login.logSteps is set to false
+     * no steps should get logged.
+     * This is usefully if the user wants shorter logs.
+     *
+     * @return boolean that is to true if logging is wanted and to false if logging is unwanted
+     */
+    private boolean checkIfStepLoggingIsConfigured(){
+        ConfigMap config = QtafFactory.getConfiguration();
+        return config.getBoolean("logging.logSteps");
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/event_subscriber/step/StepLoggerSubscriber.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/event_subscriber/step/StepLoggerSubscriber.java
@@ -1,7 +1,7 @@
 package de.qytera.qtaf.core.event_subscriber.step;
 
 import de.qytera.qtaf.core.QtafFactory;
-import de.qytera.qtaf.core.config.entity.ConfigMap;
+import de.qytera.qtaf.core.config.helper.QtafTestExecutionConfigHelper;
 import de.qytera.qtaf.core.console.ConsoleColors;
 import de.qytera.qtaf.core.context.IQtafTestContext;
 import de.qytera.qtaf.core.events.QtafEvents;
@@ -279,7 +279,7 @@ public class StepLoggerSubscriber implements IEventSubscriber {
      * @param message           log message
      */
     private void log(StepExecutionInfo stepExecutionInfo, String message) {
-        if (checkIfStepLoggingIsConfigured()){
+        if (QtafTestExecutionConfigHelper.isStepLoggingEnabled()) {
             String assertionMessage = "[Step] [%s] [%s] %s: %s";
             String stepMessage = "[Step] [%s] [%s] %s";
 
@@ -315,19 +315,5 @@ public class StepLoggerSubscriber implements IEventSubscriber {
                 }
             }
         }
-    }
-
-    /**
-     * The QTAF-User has the option to configure
-     * if the test steps should get logged to the console.
-     * If in the qtaf.json the login.logSteps is set to false
-     * no steps should get logged.
-     * This is usefully if the user wants shorter logs.
-     *
-     * @return boolean that is to true if logging is wanted and to false if logging is unwanted
-     */
-    private boolean checkIfStepLoggingIsConfigured(){
-        ConfigMap config = QtafFactory.getConfiguration();
-        return config.getBoolean("logging.logSteps");
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/testng/event_subscriber/TestNGLoggingSubscriber.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/testng/event_subscriber/TestNGLoggingSubscriber.java
@@ -227,7 +227,7 @@ public class TestNGLoggingSubscriber implements IEventSubscriber {
         String methodName = iTestResult.getMethod().getMethodName();
         logger.info("[Test] [%s] %s"
                 .formatted(
-                        packageAndClassName + "." +  methodName,
+                        packageAndClassName + "." + methodName,
                         message
                 )
         );

--- a/qtaf-core/src/main/java/de/qytera/qtaf/testng/event_subscriber/TestNGLoggingSubscriber.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/testng/event_subscriber/TestNGLoggingSubscriber.java
@@ -223,10 +223,11 @@ public class TestNGLoggingSubscriber implements IEventSubscriber {
      * @param message     Log message
      */
     private void log(ITestResult iTestResult, String message) {
-        logger.info("[Test] [%s] [%s] %s"
+        String packageAndClassName = TestResultHelper.getTestContextInstance(iTestResult).getClass().getName();
+        String methodName = iTestResult.getMethod().getMethodName();
+        logger.info("[Test] [%s] %s"
                 .formatted(
-                        iTestResult.hashCode(),
-                        TestResultHelper.getTestContextInstance(iTestResult).getClass().getName(),
+                        packageAndClassName + "." +  methodName,
                         message
                 )
         );

--- a/qtaf-core/src/main/resources/qtaf.json
+++ b/qtaf-core/src/main/resources/qtaf.json
@@ -22,7 +22,8 @@
     }
   },
   "logging": {
-    "enabled": true
+    "enabled": true,
+    "logSteps": false
   },
   "xray": {
     "enabled": false,

--- a/qtaf-core/src/test/java/de/qytera/qtaf/core/event_subscriber/StepLoggerSubscriberTests.java
+++ b/qtaf-core/src/test/java/de/qytera/qtaf/core/event_subscriber/StepLoggerSubscriberTests.java
@@ -1,31 +1,127 @@
 package de.qytera.qtaf.core.event_subscriber;
 
 import de.qytera.qtaf.core.QtafFactory;
-import de.qytera.qtaf.core.config.entity.ConfigMap;
+import de.qytera.qtaf.core.config.annotations.TestFeature;
+import de.qytera.qtaf.core.config.helper.QtafTestExecutionConfigHelper;
+import de.qytera.qtaf.core.console.ConsoleColors;
 import de.qytera.qtaf.core.event_subscriber.step.StepLoggerSubscriber;
+import de.qytera.qtaf.core.events.QtafEvents;
+import de.qytera.qtaf.core.guice.annotations.Step;
+import de.qytera.qtaf.core.guice.invokation.StepExecutionInfo;
+import de.qytera.qtaf.core.log.Logger;
+import de.qytera.qtaf.core.log.model.collection.TestScenarioLogCollection;
+import de.qytera.qtaf.core.log.model.message.StepInformationLogMessage;
+import de.qytera.qtaf.testng.context.QtafTestNGContext;
+import org.aopalliance.intercept.MethodInvocation;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.testng.Assert;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Method;
-import java.lang.reflect.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.mockito.ArgumentMatchers.anyString;
 
 public class StepLoggerSubscriberTests {
 
-    @Test(description = "Test initialization")
-    public void testCheckIfStepLoggingIsConfigured() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-
-        Method checkIfStepLoggingIsConfigured = StepLoggerSubscriber.class.getDeclaredMethod("checkIfStepLoggingIsConfigured");
-        checkIfStepLoggingIsConfigured.setAccessible(true);
-        ConfigMap config = QtafFactory.getConfiguration();
-
-        StepLoggerSubscriber stepLoggerSubscriber = new StepLoggerSubscriber();
-
-        config.setBoolean("logging.logSteps", true);
-        Assert.assertTrue((Boolean) checkIfStepLoggingIsConfigured.invoke(stepLoggerSubscriber));
-
-        config.setBoolean("logging.logSteps", false);
-        Assert.assertFalse((Boolean) checkIfStepLoggingIsConfigured.invoke(stepLoggerSubscriber));
-
-        checkIfStepLoggingIsConfigured.setAccessible(false);
+    @DataProvider
+    public Object[][] provideExpectedLogs() {
+        return Stream.of(
+                new Object[]{
+                        true,
+                        List.of(
+                                "[Step] [0] [sleep] started",
+                                "[Step] [0] [sleep] %s".formatted(ConsoleColors.green("success")),
+                                "[Step] [0] [wake up] started",
+                                "[Step] [0] [wake up] %s".formatted(ConsoleColors.red("failure"))
+                        )
+                },
+                new Object[]{
+                        false,
+                        Collections.emptyList()
+                }
+        ).toArray(Object[][]::new);
     }
+
+    @Test(description = "Test logging when step logging is enabled", dataProvider = "provideExpectedLogs")
+    public void testStepsLogging(boolean enableStepLogging, List<String> expectedMessages) throws NoSuchMethodException {
+
+        QtafFactory.getConfiguration().setBoolean(QtafTestExecutionConfigHelper.LOGGING_LOG_STEPS, enableStepLogging);
+        List<String> messages = new ArrayList<>();
+
+        // Our mock object containing step-annotated methods.
+        QtafTestNGContext context = new NightTime();
+        context.setLogCollection(TestScenarioLogCollection.createTestScenarioLogCollection(
+                "0",
+                NightTime.class.getCanonicalName(),
+                "0",
+                "testMorningRoutine"
+        ));
+
+        try (MockedStatic<QtafFactory> qtafFactory = Mockito.mockStatic(QtafFactory.class, Mockito.CALLS_REAL_METHODS)) {
+            Logger logger = Mockito.mock(Logger.class);
+            qtafFactory.when(QtafFactory::getLogger).thenReturn(logger);
+
+            new StepLoggerSubscriber().initialize();
+
+            Mockito.doAnswer(answer -> {
+                messages.add(answer.getArgument(0, String.class));
+                return null;
+            }).when(logger).info(anyString());
+
+            Step step = NightTime.class.getMethod("doSleep").getAnnotation(Step.class);
+            StepExecutionInfo stepExecutionInfo = new StepExecutionInfo();
+            stepExecutionInfo.setLogMessage(new StepInformationLogMessage("doSleep", "still dreaming"));
+            stepExecutionInfo.setAnnotation(step);
+            stepExecutionInfo.setMethodInvocation(getInvocation(context, "doSleep"));
+            QtafEvents.beforeStepExecution.onNext(stepExecutionInfo);
+            QtafEvents.stepExecutionSuccess.onNext(stepExecutionInfo);
+
+            step = NightTime.class.getMethod("doWakeUp").getAnnotation(Step.class);
+            stepExecutionInfo = new StepExecutionInfo();
+            stepExecutionInfo.setLogMessage(new StepInformationLogMessage("doWakeUp", "too early man"));
+            stepExecutionInfo.setAnnotation(step);
+            stepExecutionInfo.setMethodInvocation(getInvocation(context, "doWakeUp"));
+            QtafEvents.beforeStepExecution.onNext(stepExecutionInfo);
+            QtafEvents.stepExecutionFailure.onNext(stepExecutionInfo);
+        }
+
+        Assert.assertEquals(messages, expectedMessages);
+    }
+
+    @TestFeature(name = "Night time")
+    private static final class NightTime extends QtafTestNGContext {
+
+        @Step(name = "sleep")
+        public String doSleep() {
+            return "still dreaming";
+        }
+
+        @Step(name = "wake up")
+        public String doWakeUp() {
+            return "too early man";
+        }
+
+    }
+
+    private MethodInvocation getInvocation(Object context, String methodName) {
+        try {
+            Method method = NightTime.class.getMethod(methodName);
+            MethodInvocation methodInvocation = Mockito.mock(MethodInvocation.class, invocation -> {
+                throw new UnsupportedOperationException();
+            });
+            Mockito.doReturn(method).when(methodInvocation).getMethod();
+            Mockito.doReturn(context).when(methodInvocation).getThis();
+            Mockito.doReturn(new Object[0]).when(methodInvocation).getArguments();
+            return methodInvocation;
+        } catch (NoSuchMethodException e) {
+            throw new UnsupportedOperationException(e);
+        }
+    }
+
 }

--- a/qtaf-core/src/test/java/de/qytera/qtaf/core/event_subscriber/StepLoggerSubscriberTests.java
+++ b/qtaf-core/src/test/java/de/qytera/qtaf/core/event_subscriber/StepLoggerSubscriberTests.java
@@ -1,0 +1,31 @@
+package de.qytera.qtaf.core.event_subscriber;
+
+import de.qytera.qtaf.core.QtafFactory;
+import de.qytera.qtaf.core.config.entity.ConfigMap;
+import de.qytera.qtaf.core.event_subscriber.step.StepLoggerSubscriber;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.*;
+
+public class StepLoggerSubscriberTests {
+
+    @Test(description = "Test initialization")
+    public void testCheckIfStepLoggingIsConfigured() throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+
+        Method checkIfStepLoggingIsConfigured = StepLoggerSubscriber.class.getDeclaredMethod("checkIfStepLoggingIsConfigured");
+        checkIfStepLoggingIsConfigured.setAccessible(true);
+        ConfigMap config = QtafFactory.getConfiguration();
+
+        StepLoggerSubscriber stepLoggerSubscriber = new StepLoggerSubscriber();
+
+        config.setBoolean("logging.logSteps", true);
+        Assert.assertTrue((Boolean) checkIfStepLoggingIsConfigured.invoke(stepLoggerSubscriber));
+
+        config.setBoolean("logging.logSteps", false);
+        Assert.assertFalse((Boolean) checkIfStepLoggingIsConfigured.invoke(stepLoggerSubscriber));
+
+        checkIfStepLoggingIsConfigured.setAccessible(false);
+    }
+}

--- a/qtaf-core/src/test/java/de/qytera/qtaf/testng/event_subscriber/TestNGLoggingSubscriberTest.java
+++ b/qtaf-core/src/test/java/de/qytera/qtaf/testng/event_subscriber/TestNGLoggingSubscriberTest.java
@@ -1,0 +1,11 @@
+package de.qytera.qtaf.testng.event_subscriber;
+
+import org.testng.annotations.Test;
+
+public class TestNGLoggingSubscriberTest {
+    @Test
+    public void initialiseTest() {
+        TestNGLoggingSubscriber testNGLoggingSubscriber = new TestNGLoggingSubscriber();
+        testNGLoggingSubscriber.initialize();
+    }
+}

--- a/qtaf-core/src/test/java/de/qytera/qtaf/testng/event_subscriber/TestNGLoggingSubscriberTest.java
+++ b/qtaf-core/src/test/java/de/qytera/qtaf/testng/event_subscriber/TestNGLoggingSubscriberTest.java
@@ -1,11 +1,129 @@
 package de.qytera.qtaf.testng.event_subscriber;
 
+import de.qytera.qtaf.core.QtafFactory;
+import de.qytera.qtaf.core.config.annotations.TestFeature;
+import de.qytera.qtaf.core.console.ConsoleColors;
+import de.qytera.qtaf.core.context.IQtafTestContext;
+import de.qytera.qtaf.core.events.QtafEvents;
+import de.qytera.qtaf.core.events.payload.IQtafTestEventPayload;
+import de.qytera.qtaf.core.log.Logger;
+import de.qytera.qtaf.testng.context.QtafTestNGContext;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.ITestNGMethod;
+import org.testng.ITestResult;
 import org.testng.annotations.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyString;
+
 public class TestNGLoggingSubscriberTest {
-    @Test
-    public void initialiseTest() {
-        TestNGLoggingSubscriber testNGLoggingSubscriber = new TestNGLoggingSubscriber();
-        testNGLoggingSubscriber.initialize();
+
+    @Test(description = "Test logging when tests succeed")
+    public void testLoggingTestSuccess() {
+        List<String> loggedMessages = new ArrayList<>();
+        try (MockedStatic<QtafFactory> qtafFactory = Mockito.mockStatic(QtafFactory.class, Mockito.CALLS_REAL_METHODS)) {
+            Logger logger = Mockito.mock(Logger.class);
+            qtafFactory.when(QtafFactory::getLogger).thenReturn(logger);
+
+            new TestNGLoggingSubscriber().initialize();
+
+            Mockito.doAnswer(answer -> {
+                loggedMessages.add(answer.getArgument(0, String.class));
+                return null;
+            }).when(logger).info(anyString());
+
+            MiniContext testClass = new MiniContext();
+            ITestNGMethod testMethod = getTestMethod("testMethod");
+            ITestResult testResult = getTestResult(
+                    testClass,
+                    testMethod
+            );
+
+            QtafEvents.testSuccess.onNext(getTestEventPayload(testResult));
+        }
+        Assert.assertEquals(
+                loggedMessages,
+                List.of(
+                        "[Test] [de.qytera.qtaf.testng.event_subscriber.TestNGLoggingSubscriberTest$MiniContext.testMethod] %s"
+                                .formatted(
+                                        ConsoleColors.greenBright("success")
+                                )
+                )
+        );
     }
+
+    @Test(description = "Test logging when tests fail")
+    public void testLoggingTestFailure() {
+        List<String> loggedMessages = new ArrayList<>();
+        try (MockedStatic<QtafFactory> qtafFactory = Mockito.mockStatic(QtafFactory.class, Mockito.CALLS_REAL_METHODS)) {
+            Logger logger = Mockito.mock(Logger.class);
+            qtafFactory.when(QtafFactory::getLogger).thenReturn(logger);
+
+            new TestNGLoggingSubscriber().initialize();
+
+            Mockito.doAnswer(answer -> {
+                loggedMessages.add(answer.getArgument(0, String.class));
+                return null;
+            }).when(logger).info(anyString());
+
+            MiniContext testClass = new MiniContext();
+            ITestNGMethod testMethod = getTestMethod("testMethod");
+            ITestResult testResult = getTestResult(
+                    testClass,
+                    testMethod
+            );
+
+            QtafEvents.testFailure.onNext(getTestEventPayload(testResult));
+        }
+        Assert.assertEquals(
+                loggedMessages,
+                List.of(
+                        "[Test] [de.qytera.qtaf.testng.event_subscriber.TestNGLoggingSubscriberTest$MiniContext.testMethod] %s"
+                                .formatted(
+                                        ConsoleColors.redBright("failure")
+                                )
+                )
+        );
+    }
+
+    private IQtafTestEventPayload getTestEventPayload(
+            ITestResult originalEvent
+    ) {
+        IQtafTestEventPayload payload = Mockito.mock(IQtafTestEventPayload.class, invocation -> {
+            throw new UnsupportedOperationException();
+        });
+        Mockito.doReturn(originalEvent).when(payload).getOriginalEvent();
+        return payload;
+    }
+
+    private ITestResult getTestResult(
+            IQtafTestContext context,
+            ITestNGMethod method
+    ) {
+        ITestResult result = Mockito.mock(ITestResult.class, invocation -> {
+            throw new UnsupportedOperationException();
+        });
+        Mockito.doReturn(method).when(result).getMethod();
+        Mockito.doReturn(context).when(result).getInstance();
+        return result;
+    }
+
+    public ITestNGMethod getTestMethod(String methodName) {
+        ITestNGMethod method = Mockito.mock(ITestNGMethod.class, invocation -> {
+            throw new UnsupportedOperationException();
+        });
+        Mockito.doReturn(methodName).when(method).getMethodName();
+        return method;
+    }
+
+    @TestFeature(name = "Mini context")
+    private static final class MiniContext extends QtafTestNGContext {
+
+
+    }
+
 }


### PR DESCRIPTION
The user can now configure if he wants the steps of a test case to get logged. For shorter log messages,
the steps can be disabled in the qtaf.json.
In addition, the corresponding method of the test case is now displayed for quicker debugging when analyzing the test results.

BREAKING: The hashCode won't get printed to the console anymore, to shorten the message.
SOLVES: #279