### PR TITLE
Add log message enhancing

### DIFF
--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/events/EventListenerInitializer.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/events/EventListenerInitializer.java
@@ -3,6 +3,8 @@ package de.qytera.qtaf.core.events;
 import de.qytera.qtaf.core.events.interfaces.IEventSubscriber;
 import de.qytera.qtaf.core.reflection.ClassLoader;
 
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -48,5 +50,14 @@ public class EventListenerInitializer {
 
         // Save initialization status
         isInitialized = true;
+    }
+
+    /**
+     * Returns all event subscribers which were initialized by QTAF.
+     *
+     * @return the event subscribers
+     */
+    public static Collection<IEventSubscriber> getEventSubscribers() {
+        return Collections.unmodifiableCollection(EventListenerInitializer.instances.values());
     }
 }

--- a/qtaf-core/src/main/java/de/qytera/qtaf/testng/event_subscriber/TestNGLoggingSubscriber.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/testng/event_subscriber/TestNGLoggingSubscriber.java
@@ -15,7 +15,11 @@ import io.cucumber.testng.CucumberOptions;
 import org.testng.ITestResult;
 
 import java.lang.annotation.Annotation;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
 
 /**
  * Event subscriber that reacts to Qtaf lifecycle events and creates log messages.
@@ -31,6 +35,11 @@ public class TestNGLoggingSubscriber implements IEventSubscriber {
      * Logger.
      */
     private final Logger logger = QtafFactory.getLogger();
+
+    /**
+     * Contains enhancers which are called when printing a log message.
+     */
+    private final List<Function<ITestResult, Optional<String>>> logMessageEnhancers = new ArrayList<>();
 
     /**
      * Subscribe to events and register event handlers.
@@ -57,12 +66,20 @@ public class TestNGLoggingSubscriber implements IEventSubscriber {
     }
 
     /**
+     * Registers a log message enhancer which will be called whenever this subscriber prints a log message.
+     *
+     * @param enhancer the enhancing function
+     */
+    public void addLogMessageEnhancer(Function<ITestResult, Optional<String>> enhancer) {
+        this.logMessageEnhancers.add(enhancer);
+    }
+
+    /**
      * This method is called every time before a test is executed.
      *
      * @param iQtafTestEventPayload Test context object
      * @deprecated
      */
-
     @Deprecated
     private void onTestStarted(IQtafTestEventPayload iQtafTestEventPayload) {
         // Check if this listener is responsible for this event
@@ -225,12 +242,13 @@ public class TestNGLoggingSubscriber implements IEventSubscriber {
     private void log(ITestResult iTestResult, String message) {
         String packageAndClassName = TestResultHelper.getTestContextInstance(iTestResult).getClass().getName();
         String methodName = iTestResult.getMethod().getMethodName();
-        logger.info("[Test] [%s] %s"
-                .formatted(
-                        packageAndClassName + "." + methodName,
-                        message
-                )
-        );
+        StringBuilder logMessage = new StringBuilder("[Test] ");
+        for (Function<ITestResult, Optional<String>> enhancer : logMessageEnhancers) {
+            Optional<String> result = enhancer.apply(iTestResult);
+            result.ifPresent(s -> logMessage.append("[%s] ".formatted(s)));
+        }
+        logMessage.append("[%s.%s] %s".formatted(packageAndClassName, methodName, message));
+        logger.info(logMessage.toString());
     }
 
     /**

--- a/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/event_subscriber/InitializationSubscriber.java
+++ b/qtaf-xray-plugin/src/main/java/de/qytera/qtaf/xray/event_subscriber/InitializationSubscriber.java
@@ -1,0 +1,58 @@
+package de.qytera.qtaf.xray.event_subscriber;
+
+import de.qytera.qtaf.core.events.EventListenerInitializer;
+import de.qytera.qtaf.core.events.QtafEvents;
+import de.qytera.qtaf.core.events.interfaces.IEventSubscriber;
+import de.qytera.qtaf.testng.event_subscriber.TestNGLoggingSubscriber;
+import de.qytera.qtaf.xray.annotation.XrayTest;
+import de.qytera.qtaf.xray.config.XrayConfigHelper;
+import org.testng.internal.ConstructorOrMethod;
+import rx.Subscription;
+
+import java.lang.reflect.Method;
+import java.util.Optional;
+
+/**
+ * Event subscriber which listens for QTAF initialization events.
+ */
+public class InitializationSubscriber implements IEventSubscriber {
+
+    /**
+     * Event subscription.
+     */
+    private Subscription eventInitializationSubscription;
+
+    @Override
+    public void initialize() {
+        if (eventInitializationSubscription != null) {
+            return;
+        }
+        this.eventInitializationSubscription = QtafEvents.eventListenersInitialized.subscribe(this::onEventListenersInitialized);
+    }
+
+    /**
+     * Method that is executed when all event listeners have been initialized.
+     *
+     * @param v ignored
+     */
+    private void onEventListenersInitialized(Void v) {
+        if (!XrayConfigHelper.isEnabled()) {
+            return;
+        }
+        for (IEventSubscriber eventSubscriber : EventListenerInitializer.getEventSubscribers()) {
+            if (eventSubscriber instanceof TestNGLoggingSubscriber subscriber) {
+                subscriber.addLogMessageEnhancer(testResult -> {
+                    ConstructorOrMethod constructorOrMethod = testResult.getMethod().getConstructorOrMethod();
+                    if (constructorOrMethod.getMethod() != null) {
+                        Method method = constructorOrMethod.getMethod();
+                        XrayTest xrayAnnotation = method.getAnnotation(XrayTest.class);
+                        if (xrayAnnotation != null) {
+                            return Optional.of(xrayAnnotation.key());
+                        }
+                    }
+                    return Optional.empty();
+                });
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds log message customization to the TestNG event listener. It is now possible to add arbitrary information to log messages, such as Xray annotation keys:

```console
// Old
[Test] [de.qytera.qtaf.xray.event_subscriber.InitializationSubscriberTest$1.mockMethod] success
// New
[Test] [QTAF-123] [de.qytera.qtaf.xray.event_subscriber.InitializationSubscriberTest$1.mockMethod] success
```

The logging subscriber provides a method for registering enhancers:

```java
    /**
     * Registers a log message enhancer which will be called whenever this subscriber prints a log message.
     *
     * @param enhancer the enhancing function
     */
    public void addLogMessageEnhancer(Function<ITestResult, Optional<String>> enhancer) {
        this.logMessageEnhancers.add(enhancer);
    }
```

The enhancing function receives the test result object and can decide whether to add more log output.