### PR TITLE
Make driver preferences configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.qytera</groupId>
     <artifactId>qtaf</artifactId>
-    <version>0.2.14</version>
+    <version>0.2.15</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/qtaf-allure-plugin/pom.xml
+++ b/qtaf-allure-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.14</version>
+        <version>0.2.15</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-aws-devicefarm/pom.xml
+++ b/qtaf-aws-devicefarm/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.14</version>
+        <version>0.2.15</version>
     </parent>
 
     <artifactId>qtaf-aws-devicefarm</artifactId>

--- a/qtaf-core/pom.xml
+++ b/qtaf-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.14</version>
+        <version>0.2.15</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/CapabilityFactory.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/CapabilityFactory.java
@@ -11,6 +11,7 @@ import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
@@ -32,10 +33,7 @@ class CapabilityFactory {
      */
     public static ChromeOptions getCapabilitiesChrome() {
         useJdkHttpClient();
-        ChromeOptions options = new ChromeOptions();
-        options.addArguments(SeleniumDriverConfigHelper.getDriverOptions().toArray(String[]::new));
-        options = options.merge(SeleniumDriverConfigHelper.getDriverCapabilities());
-        return options;
+        return getCapabilitiesChromeRemote();
     }
 
     /**
@@ -47,6 +45,7 @@ class CapabilityFactory {
         ChromeOptions options = new ChromeOptions();
         options.addArguments(SeleniumDriverConfigHelper.getDriverOptions().toArray(String[]::new));
         options = options.merge(SeleniumDriverConfigHelper.getDriverCapabilities());
+        SeleniumDriverConfigHelper.getDriverPreferences().forEach(options::setExperimentalOption);
         return options;
     }
 
@@ -57,10 +56,7 @@ class CapabilityFactory {
      */
     public static EdgeOptions getCapabilitiesEdge() {
         useJdkHttpClient();
-        EdgeOptions options = new EdgeOptions();
-        options.addArguments(SeleniumDriverConfigHelper.getDriverOptions().toArray(String[]::new));
-        options = options.merge(SeleniumDriverConfigHelper.getDriverCapabilities());
-        return options;
+        return getCapabilitiesEdgeRemote();
     }
 
     /**
@@ -72,6 +68,7 @@ class CapabilityFactory {
         EdgeOptions options = new EdgeOptions();
         options.addArguments(SeleniumDriverConfigHelper.getDriverOptions().toArray(String[]::new));
         options = options.merge(SeleniumDriverConfigHelper.getDriverCapabilities());
+        SeleniumDriverConfigHelper.getDriverPreferences().forEach(options::setExperimentalOption);
         return options;
     }
 
@@ -82,10 +79,7 @@ class CapabilityFactory {
      */
     public static FirefoxOptions getCapabilitiesFirefox() {
         useJdkHttpClient();
-        FirefoxOptions options = new FirefoxOptions();
-        options.addArguments(SeleniumDriverConfigHelper.getDriverOptions().toArray(String[]::new));
-        options = options.merge(SeleniumDriverConfigHelper.getDriverCapabilities());
-        return options;
+        return getCapabilitiesFirefoxRemote();
     }
 
     /**
@@ -97,6 +91,12 @@ class CapabilityFactory {
         FirefoxOptions options = new FirefoxOptions();
         options.addArguments(SeleniumDriverConfigHelper.getDriverOptions().toArray(String[]::new));
         options = options.merge(SeleniumDriverConfigHelper.getDriverCapabilities());
+        Map<String, Object> preferences = SeleniumDriverConfigHelper.getDriverPreferences();
+        if (!preferences.isEmpty()) {
+            FirefoxProfile profile = new FirefoxProfile();
+            preferences.forEach(profile::setPreference);
+            options.setProfile(profile);
+        }
         return options;
     }
 

--- a/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/helper/SeleniumDriverConfigHelper.java
+++ b/qtaf-core/src/main/java/de/qytera/qtaf/core/selenium/helper/SeleniumDriverConfigHelper.java
@@ -11,6 +11,8 @@ import lombok.NoArgsConstructor;
 import org.openqa.selenium.Capabilities;
 import org.openqa.selenium.ImmutableCapabilities;
 import org.openqa.selenium.MutableCapabilities;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.firefox.FirefoxProfile;
 
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -49,6 +51,12 @@ public class SeleniumDriverConfigHelper {
      * Additional driver capabilities to consider during driver instantiation.
      */
     public static final String DRIVER_CAPABILITIES = "driver.capabilities";
+    /**
+     * Additional driver preferences to consider during driver instantiation. When using Firefox, they will be inserted
+     * into a {@link FirefoxProfile}. For Chromium, they will be inserted using
+     * {@link ChromeOptions#setExperimentalOption(String, Object) experimental options}.
+     */
+    public static final String DRIVER_PREFERENCES = "driver.preferences";
     /**
      * Whether the driver should quit after testing.
      */
@@ -151,6 +159,15 @@ public class SeleniumDriverConfigHelper {
         MutableCapabilities capabilities = new MutableCapabilities();
         toPrimitive(config.getMap(DRIVER_CAPABILITIES)).forEach(capabilities::setCapability);
         return ImmutableCapabilities.copyOf(capabilities);
+    }
+
+    /**
+     * Returns the configured driver preferences to consider during driver instantiation.
+     *
+     * @return the driver preferences
+     */
+    public static Map<String, Object> getDriverPreferences() {
+        return toPrimitive(config.getMap(DRIVER_PREFERENCES));
     }
 
     private static Map<String, Object> toPrimitive(Map<String, JsonElement> map) {

--- a/qtaf-core/src/main/resources/qtaf.json
+++ b/qtaf-core/src/main/resources/qtaf.json
@@ -20,7 +20,8 @@
       "afterStepFailure": true
     },
     "options": [],
-    "capabilities": {}
+    "capabilities": {},
+    "preferences": {}
   },
   "logging": {
     "enabled": true,

--- a/qtaf-core/src/test/java/de/qytera/qtaf/core/selenium/CapabilityFactoryTest.java
+++ b/qtaf-core/src/test/java/de/qytera/qtaf/core/selenium/CapabilityFactoryTest.java
@@ -10,6 +10,7 @@ import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.edge.EdgeOptions;
 import org.openqa.selenium.firefox.FirefoxOptions;
+import org.openqa.selenium.firefox.FirefoxProfile;
 import org.openqa.selenium.ie.InternetExplorerOptions;
 import org.testng.Assert;
 import org.testng.annotations.BeforeMethod;
@@ -39,6 +40,14 @@ public class CapabilityFactoryTest {
             )
     );
 
+    private static final Map<String, Object> PREFERENCES = Map.of(
+            "f", true,
+            "g", Map.of(
+                    "h", List.of(1L, 2.14D, 3L, 5L),
+                    "j", List.of(List.of(10L), Map.of("k", true))
+            )
+    );
+
     @Test
     public void testGetCapabilitiesChrome() {
         try (MockedStatic<SeleniumDriverConfigHelper> helper = Mockito.mockStatic(SeleniumDriverConfigHelper.class)) {
@@ -48,11 +57,26 @@ public class CapabilityFactoryTest {
             ChromeOptions actualOptions = CapabilityFactory.getCapabilitiesChrome();
             helper.verify(SeleniumDriverConfigHelper::getDriverOptions, Mockito.times(1));
             helper.verify(SeleniumDriverConfigHelper::getDriverCapabilities, Mockito.times(1));
-            helper.verifyNoMoreInteractions();
 
             ChromeOptions expectedOptions = new ChromeOptions();
             expectedOptions.addArguments(OPTIONS);
             expectedOptions = expectedOptions.merge(CAPABILITIES);
+
+            Assert.assertEquals(actualOptions, expectedOptions);
+        }
+    }
+
+    @Test
+    public void testGetCapabilitiesChromeWithPreferences() {
+        try (MockedStatic<SeleniumDriverConfigHelper> helper = Mockito.mockStatic(SeleniumDriverConfigHelper.class)) {
+            helper.when(SeleniumDriverConfigHelper::getDriverPreferences).thenReturn(PREFERENCES);
+            helper.when(SeleniumDriverConfigHelper::getDriverCapabilities).thenReturn(new MutableCapabilities());
+
+            ChromeOptions actualOptions = CapabilityFactory.getCapabilitiesChrome();
+            helper.verify(SeleniumDriverConfigHelper::getDriverPreferences, Mockito.times(1));
+
+            ChromeOptions expectedOptions = new ChromeOptions();
+            PREFERENCES.forEach(expectedOptions::setExperimentalOption);
 
             Assert.assertEquals(actualOptions, expectedOptions);
         }
@@ -67,11 +91,26 @@ public class CapabilityFactoryTest {
             ChromeOptions actualOptions = CapabilityFactory.getCapabilitiesChromeRemote();
             helper.verify(SeleniumDriverConfigHelper::getDriverOptions, Mockito.times(1));
             helper.verify(SeleniumDriverConfigHelper::getDriverCapabilities, Mockito.times(1));
-            helper.verifyNoMoreInteractions();
 
             ChromeOptions expectedOptions = new ChromeOptions();
             expectedOptions.addArguments(OPTIONS);
             expectedOptions = expectedOptions.merge(CAPABILITIES);
+
+            Assert.assertEquals(actualOptions, expectedOptions);
+        }
+    }
+
+    @Test
+    public void testGetCapabilitiesChromeRemoteWithPreferences() {
+        try (MockedStatic<SeleniumDriverConfigHelper> helper = Mockito.mockStatic(SeleniumDriverConfigHelper.class)) {
+            helper.when(SeleniumDriverConfigHelper::getDriverPreferences).thenReturn(PREFERENCES);
+            helper.when(SeleniumDriverConfigHelper::getDriverCapabilities).thenReturn(new MutableCapabilities());
+
+            ChromeOptions actualOptions = CapabilityFactory.getCapabilitiesChromeRemote();
+            helper.verify(SeleniumDriverConfigHelper::getDriverPreferences, Mockito.times(1));
+
+            ChromeOptions expectedOptions = new ChromeOptions();
+            PREFERENCES.forEach(expectedOptions::setExperimentalOption);
 
             Assert.assertEquals(actualOptions, expectedOptions);
         }
@@ -86,11 +125,26 @@ public class CapabilityFactoryTest {
             EdgeOptions actualOptions = CapabilityFactory.getCapabilitiesEdge();
             helper.verify(SeleniumDriverConfigHelper::getDriverOptions, Mockito.times(1));
             helper.verify(SeleniumDriverConfigHelper::getDriverCapabilities, Mockito.times(1));
-            helper.verifyNoMoreInteractions();
 
             EdgeOptions expectedOptions = new EdgeOptions();
             expectedOptions.addArguments(OPTIONS);
             expectedOptions = expectedOptions.merge(CAPABILITIES);
+
+            Assert.assertEquals(actualOptions, expectedOptions);
+        }
+    }
+
+    @Test
+    public void testGetCapabilitiesEdgeWithPreferences() {
+        try (MockedStatic<SeleniumDriverConfigHelper> helper = Mockito.mockStatic(SeleniumDriverConfigHelper.class)) {
+            helper.when(SeleniumDriverConfigHelper::getDriverPreferences).thenReturn(PREFERENCES);
+            helper.when(SeleniumDriverConfigHelper::getDriverCapabilities).thenReturn(new MutableCapabilities());
+
+            EdgeOptions actualOptions = CapabilityFactory.getCapabilitiesEdge();
+            helper.verify(SeleniumDriverConfigHelper::getDriverPreferences, Mockito.times(1));
+
+            EdgeOptions expectedOptions = new EdgeOptions();
+            PREFERENCES.forEach(expectedOptions::setExperimentalOption);
 
             Assert.assertEquals(actualOptions, expectedOptions);
         }
@@ -105,11 +159,26 @@ public class CapabilityFactoryTest {
             EdgeOptions actualOptions = CapabilityFactory.getCapabilitiesEdgeRemote();
             helper.verify(SeleniumDriverConfigHelper::getDriverOptions, Mockito.times(1));
             helper.verify(SeleniumDriverConfigHelper::getDriverCapabilities, Mockito.times(1));
-            helper.verifyNoMoreInteractions();
 
             EdgeOptions expectedOptions = new EdgeOptions();
             expectedOptions.addArguments(OPTIONS);
             expectedOptions = expectedOptions.merge(CAPABILITIES);
+
+            Assert.assertEquals(actualOptions, expectedOptions);
+        }
+    }
+
+    @Test
+    public void testGetCapabilitiesEdgeRemoteWithPreferences() {
+        try (MockedStatic<SeleniumDriverConfigHelper> helper = Mockito.mockStatic(SeleniumDriverConfigHelper.class)) {
+            helper.when(SeleniumDriverConfigHelper::getDriverPreferences).thenReturn(PREFERENCES);
+            helper.when(SeleniumDriverConfigHelper::getDriverCapabilities).thenReturn(new MutableCapabilities());
+
+            EdgeOptions actualOptions = CapabilityFactory.getCapabilitiesEdgeRemote();
+            helper.verify(SeleniumDriverConfigHelper::getDriverPreferences, Mockito.times(1));
+
+            EdgeOptions expectedOptions = new EdgeOptions();
+            PREFERENCES.forEach(expectedOptions::setExperimentalOption);
 
             Assert.assertEquals(actualOptions, expectedOptions);
         }
@@ -124,11 +193,28 @@ public class CapabilityFactoryTest {
             FirefoxOptions actualOptions = CapabilityFactory.getCapabilitiesFirefox();
             helper.verify(SeleniumDriverConfigHelper::getDriverOptions, Mockito.times(1));
             helper.verify(SeleniumDriverConfigHelper::getDriverCapabilities, Mockito.times(1));
-            helper.verifyNoMoreInteractions();
 
             FirefoxOptions expectedOptions = new FirefoxOptions();
             expectedOptions.addArguments(OPTIONS);
             expectedOptions = expectedOptions.merge(CAPABILITIES);
+
+            Assert.assertEquals(actualOptions, expectedOptions);
+        }
+    }
+
+    @Test
+    public void testGetCapabilitiesFirefoxWithPreferences() {
+        try (MockedStatic<SeleniumDriverConfigHelper> helper = Mockito.mockStatic(SeleniumDriverConfigHelper.class)) {
+            helper.when(SeleniumDriverConfigHelper::getDriverPreferences).thenReturn(PREFERENCES);
+            helper.when(SeleniumDriverConfigHelper::getDriverCapabilities).thenReturn(new MutableCapabilities());
+
+            FirefoxOptions actualOptions = CapabilityFactory.getCapabilitiesFirefox();
+            helper.verify(SeleniumDriverConfigHelper::getDriverPreferences, Mockito.times(1));
+
+            FirefoxOptions expectedOptions = new FirefoxOptions();
+            FirefoxProfile profile = new FirefoxProfile();
+            PREFERENCES.forEach(profile::setPreference);
+            expectedOptions.setProfile(profile);
 
             Assert.assertEquals(actualOptions, expectedOptions);
         }
@@ -143,11 +229,28 @@ public class CapabilityFactoryTest {
             FirefoxOptions actualOptions = CapabilityFactory.getCapabilitiesFirefoxRemote();
             helper.verify(SeleniumDriverConfigHelper::getDriverOptions, Mockito.times(1));
             helper.verify(SeleniumDriverConfigHelper::getDriverCapabilities, Mockito.times(1));
-            helper.verifyNoMoreInteractions();
 
             FirefoxOptions expectedOptions = new FirefoxOptions();
             expectedOptions.addArguments(OPTIONS);
             expectedOptions = expectedOptions.merge(CAPABILITIES);
+
+            Assert.assertEquals(actualOptions, expectedOptions);
+        }
+    }
+
+    @Test
+    public void testGetCapabilitiesFirefoxRemoteWithPreferences() {
+        try (MockedStatic<SeleniumDriverConfigHelper> helper = Mockito.mockStatic(SeleniumDriverConfigHelper.class)) {
+            helper.when(SeleniumDriverConfigHelper::getDriverPreferences).thenReturn(PREFERENCES);
+            helper.when(SeleniumDriverConfigHelper::getDriverCapabilities).thenReturn(new MutableCapabilities());
+
+            FirefoxOptions actualOptions = CapabilityFactory.getCapabilitiesFirefoxRemote();
+            helper.verify(SeleniumDriverConfigHelper::getDriverPreferences, Mockito.times(1));
+
+            FirefoxOptions expectedOptions = new FirefoxOptions();
+            FirefoxProfile profile = new FirefoxProfile();
+            PREFERENCES.forEach(profile::setPreference);
+            expectedOptions.setProfile(profile);
 
             Assert.assertEquals(actualOptions, expectedOptions);
         }
@@ -170,6 +273,17 @@ public class CapabilityFactoryTest {
             expectedOptions = expectedOptions.merge(CAPABILITIES);
 
             Assert.assertEquals(actualOptions, expectedOptions);
+        }
+    }
+
+    @Test
+    public void testGetCapabilitiesInternetExplorerWithPreferences() {
+        try (MockedStatic<SeleniumDriverConfigHelper> helper = Mockito.mockStatic(SeleniumDriverConfigHelper.class)) {
+            helper.when(SeleniumDriverConfigHelper::getDriverPreferences).thenReturn(PREFERENCES);
+            helper.when(SeleniumDriverConfigHelper::getDriverCapabilities).thenReturn(new MutableCapabilities());
+
+            CapabilityFactory.getCapabilitiesInternetExplorer();
+            helper.verify(SeleniumDriverConfigHelper::getDriverPreferences, Mockito.times(0));
         }
     }
 
@@ -207,6 +321,25 @@ public class CapabilityFactoryTest {
     }
 
     @Test
+    public void testGetCapabilitiesAndroidWithPreferences() {
+
+        QtafFactory.getConfiguration().setString("appium.capabilities.deviceName", "Alpha");
+        QtafFactory.getConfiguration().setString("appium.capabilities.udid", "Beta");
+        QtafFactory.getConfiguration().setString("appium.capabilities.androidVersion", "Gamma");
+        QtafFactory.getConfiguration().setString("appium.capabilities.platformName", "Delta");
+        QtafFactory.getConfiguration().setString("appium.capabilities.appPackage", "Epsilon");
+        QtafFactory.getConfiguration().setString("appium.capabilities.appActivity", "Zeta");
+
+        try (MockedStatic<SeleniumDriverConfigHelper> helper = Mockito.mockStatic(SeleniumDriverConfigHelper.class)) {
+            helper.when(SeleniumDriverConfigHelper::getDriverPreferences).thenReturn(PREFERENCES);
+            helper.when(SeleniumDriverConfigHelper::getDriverCapabilities).thenReturn(new MutableCapabilities());
+
+            CapabilityFactory.getCapabilitiesAndroid();
+            helper.verify(SeleniumDriverConfigHelper::getDriverPreferences, Mockito.times(0));
+        }
+    }
+
+    @Test
     public void testGetCapabilitiesSaucelabs() {
 
         QtafFactory.getConfiguration().setString("sauce.username", "Alpha");
@@ -238,6 +371,24 @@ public class CapabilityFactoryTest {
             expectedCapabilities = expectedCapabilities.merge(CAPABILITIES);
 
             Assert.assertEquals(actualCapabilities, expectedCapabilities);
+        }
+    }
+
+    @Test
+    public void testGetCapabilitiesSaucelabsWithPreferences() {
+
+        QtafFactory.getConfiguration().setString("sauce.username", "Alpha");
+        QtafFactory.getConfiguration().setString("sauce.accessKey", "Beta");
+        QtafFactory.getConfiguration().setString("sauce.browserName", "Gamma");
+
+        try (MockedStatic<SeleniumDriverConfigHelper> helper = Mockito.mockStatic(SeleniumDriverConfigHelper.class)) {
+            helper.when(SeleniumDriverConfigHelper::getDriverPreferences).thenReturn(PREFERENCES);
+            helper.when(SeleniumDriverConfigHelper::getDriverCapabilities).thenReturn(new MutableCapabilities());
+            helper.when(SeleniumDriverConfigHelper::getDriverVersion).thenReturn("123.456.789");
+            helper.when(SeleniumDriverConfigHelper::getPlatformName).thenReturn("Unix");
+
+            CapabilityFactory.getCapabilitiesSaucelabs();
+            helper.verify(SeleniumDriverConfigHelper::getDriverPreferences, Mockito.times(0));
         }
     }
 

--- a/qtaf-core/src/test/java/de/qytera/qtaf/core/selenium/helper/SeleniumDriverConfigHelperTest.java
+++ b/qtaf-core/src/test/java/de/qytera/qtaf/core/selenium/helper/SeleniumDriverConfigHelperTest.java
@@ -76,7 +76,7 @@ public class SeleniumDriverConfigHelperTest {
 
     @Test
     public void testGetDriverCapabilitiesDefault() {
-        Assert.assertEquals(SeleniumDriverConfigHelper.getDriverOptions(), Collections.emptyList());
+        Assert.assertEquals(SeleniumDriverConfigHelper.getDriverCapabilities(), new MutableCapabilities());
     }
 
     @Test
@@ -111,6 +111,47 @@ public class SeleniumDriverConfigHelperTest {
                 )
         ));
         Assert.assertEquals(SeleniumDriverConfigHelper.getDriverCapabilities(), expectedCapabilities);
+    }
+
+    @Test
+    public void testGetDriverPreferencesDefault() {
+        Assert.assertEquals(SeleniumDriverConfigHelper.getDriverPreferences(), Collections.emptyMap());
+    }
+
+    @Test
+    public void testGetDriverPreferencesHappyPath() {
+        System.setProperty(SeleniumDriverConfigHelper.DRIVER_PREFERENCES, """
+                {
+                  "a": "good morning",
+                  "b": 3,
+                  "c": false,
+                  "d": [8080, 443],
+                  "e": {
+                    "f": true,
+                    "g": {
+                      "h": [1, 2.14, 3, null, 5],
+                      "i": null,
+                      "j": [[10], {"k": true}]
+                    }
+                  }
+                }
+                """
+        );
+        Assert.assertEquals(
+                SeleniumDriverConfigHelper.getDriverPreferences(),
+                Map.of(
+                        "a", "good morning",
+                        "b", 3L,
+                        "c", false,
+                        "d", List.of(8080L, 443L),
+                        "e", Map.of(
+                                "f", true,
+                                "g", Map.of(
+                                        "h", List.of(1L, 2.14D, 3L, 5L),
+                                        "j", List.of(List.of(10L), Map.of("k", true))
+                                )
+                        )
+                ));
     }
 
     @Test

--- a/qtaf-core/src/test/java/de/qytera/qtaf/core/selenium/helper/SeleniumDriverConfigHelperTest.java
+++ b/qtaf-core/src/test/java/de/qytera/qtaf/core/selenium/helper/SeleniumDriverConfigHelperTest.java
@@ -20,8 +20,9 @@ public class SeleniumDriverConfigHelperTest {
 
     @AfterMethod
     public void clear() {
-        System.clearProperty(SeleniumDriverConfigHelper.DRIVER_CAPABILITIES);
         System.clearProperty(SeleniumDriverConfigHelper.DRIVER_OPTIONS);
+        System.clearProperty(SeleniumDriverConfigHelper.DRIVER_CAPABILITIES);
+        System.clearProperty(SeleniumDriverConfigHelper.DRIVER_PREFERENCES);
     }
 
     @Test

--- a/qtaf-data/pom.xml
+++ b/qtaf-data/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.14</version>
+        <version>0.2.15</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-html-report-plugin/pom.xml
+++ b/qtaf-html-report-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.14</version>
+        <version>0.2.15</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-http/pom.xml
+++ b/qtaf-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.14</version>
+        <version>0.2.15</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-io/pom.xml
+++ b/qtaf-io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.14</version>
+        <version>0.2.15</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-security/pom.xml
+++ b/qtaf-security/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.14</version>
+        <version>0.2.15</version>
     </parent>
 
     <artifactId>qtaf-security</artifactId>

--- a/qtaf-testrail-plugin/pom.xml
+++ b/qtaf-testrail-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.14</version>
+        <version>0.2.15</version>
     </parent>
 
     <artifactId>qtaf-testrail-plugin</artifactId>

--- a/qtaf-xray-plugin/pom.xml
+++ b/qtaf-xray-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.14</version>
+        <version>0.2.15</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
This PR makes driver preferences configurable inside QTAF:

For example, to set the download directory for Chromium-based browsers, you can now set it up like this:
```json
{
  "driver": {
    "name": "chrome",
    "preferences": {
      "download.default_directory": "/home/me/downloads",
      "profile.default_content_settings.popups": 0
    }
  }
}
```

For Firefox:
```json
{
  "driver": {
    "name": "firefox",
    "preferences": {
      "browser.download.dir": "/home/me/downloads",
      "browser.helperApps.neverAsk.saveToDisk": "application/json"
    }
  }
}
```

---

Documentation: https://qytera-gmbh.github.io/projects/qtaf/sections/Configuration/#preferences