### PR TITLE
fix(pom.xml): downgrade versions to fix merge conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.qytera</groupId>
     <artifactId>qtaf</artifactId>
-    <version>0.2.21</version>
+    <version>0.2.19</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/qtaf-allure-plugin/pom.xml
+++ b/qtaf-allure-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.21</version>
+        <version>0.2.19</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-aws-devicefarm/pom.xml
+++ b/qtaf-aws-devicefarm/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.21</version>
+        <version>0.2.19</version>
     </parent>
 
     <artifactId>qtaf-aws-devicefarm</artifactId>

--- a/qtaf-core/pom.xml
+++ b/qtaf-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.21</version>
+        <version>0.2.19</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-data/pom.xml
+++ b/qtaf-data/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.21</version>
+        <version>0.2.19</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-html-report-plugin/pom.xml
+++ b/qtaf-html-report-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.21</version>
+        <version>0.2.19</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-http/pom.xml
+++ b/qtaf-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.21</version>
+        <version>0.2.19</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-io/pom.xml
+++ b/qtaf-io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.21</version>
+        <version>0.2.19</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-rest-assured/pom.xml
+++ b/qtaf-rest-assured/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.20</version>
+        <version>0.2.19</version>
     </parent>
 
     <artifactId>qtaf-rest-assured</artifactId>

--- a/qtaf-security/pom.xml
+++ b/qtaf-security/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.21</version>
+        <version>0.2.19</version>
     </parent>
 
     <artifactId>qtaf-security</artifactId>

--- a/qtaf-testrail-plugin/pom.xml
+++ b/qtaf-testrail-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.21</version>
+        <version>0.2.19</version>
     </parent>
 
     <artifactId>qtaf-testrail-plugin</artifactId>

--- a/qtaf-xray-plugin/pom.xml
+++ b/qtaf-xray-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.21</version>
+        <version>0.2.19</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Due to an unmerged version of "develop" to "main"
there were merge conflicts.
This changes the version number in the corresponding pom.xml files.