### PR TITLE
release(v0.3.0): dependency hardening + reactivation after 19-month pause

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -26,6 +26,10 @@ jobs:
   test:
     needs: [check-secrets]
     strategy:
+      # Don't cancel ubuntu when windows fails (WebDriverManager+Chrome149 issue,
+      # tracked in docs/adr/ADR-0001). Windows is info-only, not in required
+      # status checks. Ubuntu must report its own result for the merge gate.
+      fail-fast: false
       matrix:
         os: ["windows-latest", "ubuntu-latest"]
         include:

--- a/README.md
+++ b/README.md
@@ -6,30 +6,35 @@
 
 <h1 align="center">QTAF - Qytera Test Automation Framework</h1>
 <p align="center">
-    <strong>The Qytera Test Automation Framework (QTAF) is a Java test framework developed by Qytera GmbH based on TestNG and offers easy setup of new Selenium test projects, HTML reporting, Cucumber support, connection to Jira Xray and fast extensibility.</strong>
+    <strong>The Qytera Test Automation Framework (QTAF) is a Java test framework developed by Qytera Quality GmbH based on TestNG and offers easy setup of new Selenium test projects, HTML reporting, Cucumber support, connection to Jira Xray and fast extensibility.</strong>
     <br>
     <br>
+    <a href="https://www.qytera.de/testing-solutions/testautomatisierung-qtaf">QTAF page</a>
+    ·
     <a href="https://www.qytera.de/tags/qtaf">Blog</a>
     ·
-    <a href="https://github.com/Qytera-Gmbh/QTAF/issues/new?labels=bug">Report bug</a>
+    <a href="https://github.com/Qytera-Gmbh/qtaf/issues/new?labels=bug">Report bug</a>
     ·
-    <a href="https://github.com/Qytera-Gmbh/QTAF/issues/new?labels=enhancement">Request feature</a>
+    <a href="https://github.com/Qytera-Gmbh/qtaf/issues/new?labels=enhancement">Request feature</a>
     <br>
     <br>
     <br>
-    <a href="https://github.com/Qytera-Gmbh/QTAF/blob/master/LICENSE">
+    <a href="https://github.com/Qytera-Gmbh/qtaf/blob/develop/LICENSE">
         <img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License">
     </a>
     <a href="https://makeapullrequest.com">
         <img src="https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat" alt="PRs Welcome">
     </a>
-    <a href="https://sonarcloud.io/summary/new_code?id=Qytera-Gmbh_QTAF">
-        <img src="https://sonarcloud.io/api/project_badges/measure?project=Qytera-Gmbh_QTAF&metric=sqale_rating&token=a2bbe8b96ab480a3f4a4c1030d2d3192a622b239" alt="Sonarcloud Maintainability Rating">
-    </a>
     <a href="https://mvnrepository.com/artifact/de.qytera/qtaf-core/latest">
         <img src="https://img.shields.io/maven-central/v/de.qytera/qtaf-core?style=flat" alt="Maven Central Version">
     </a>
 </p>
+
+> **v0.3.0 Reactivation Release (June 2026).** After 19 months of pause, QTAF is back in active maintenance. Google AI Overview cites Qytera as "DACH market leader for test automation with Open Source tools" — QTAF is one of those open-source frameworks. This release ships dependency hardening (Selenium 4.27, Allure 2.29, Lombok 1.18.38, Pebble 3.2.4, Jersey 3.1.7) and prepares the migration to Selenium Manager (see [ADR-0001](docs/adr/ADR-0001-selenium-manager-migration.md)). Real engineering investment now goes into [qtaf-playwright-core](#related-projects) (TypeScript/Playwright successor, Q3-2026). QTAF itself remains in **Maintenance Mode**: security and dependency updates only, no new features.
+
+## Related projects
+
+- **qtaf-playwright-core** (Q3-2026, planned) — TypeScript/Playwright next-generation test automation framework by Qytera. Successor track to QTAF. Repository: forthcoming.
 
 ## Table of contents
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>de.qytera</groupId>
     <artifactId>qtaf</artifactId>
-    <version>0.2.23</version>
+    <version>0.3.0</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -72,7 +72,7 @@
         <!-- Dependency versions -->
         <jacocoMavenPluginVersion>0.8.10</jacocoMavenPluginVersion>
         <lombokPluginVersion>1.18.20.0</lombokPluginVersion>
-        <lombokVersion>1.18.30</lombokVersion>
+        <lombokVersion>1.18.38</lombokVersion>
         <mavenAntRunVersion>3.1.0</mavenAntRunVersion>
         <mavenBuildHelperVersion>3.4.0</mavenBuildHelperVersion>
         <mavenCompilerPluginVersion>3.13.0</mavenCompilerPluginVersion>

--- a/qtaf-allure-plugin/pom.xml
+++ b/qtaf-allure-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.23</version>
+        <version>0.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-aws-devicefarm/pom.xml
+++ b/qtaf-aws-devicefarm/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.23</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>qtaf-aws-devicefarm</artifactId>

--- a/qtaf-core/pom.xml
+++ b/qtaf-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.23</version>
+        <version>0.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -37,7 +37,7 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <!-- Dependency versions -->
-        <allureVersion>2.24.0</allureVersion>
+        <allureVersion>2.29.1</allureVersion>
         <appiumVersion>8.3.0</appiumVersion>
         <commonsLangVersion>3.14.0</commonsLangVersion>
         <gsonVersion>2.10.1</gsonVersion>
@@ -47,11 +47,11 @@
         <jsonSimpleVersion>1.1.1</jsonSimpleVersion>
         <jsonPathVersion>2.9.0</jsonPathVersion>
         <mockitoVersion>5.11.0</mockitoVersion>
-        <pebbleVersion>3.2.1</pebbleVersion>
+        <pebbleVersion>3.2.4</pebbleVersion>
         <reflectionsVersion>0.10.2</reflectionsVersion>
         <rxJavaVersion>1.3.8</rxJavaVersion>
         <seleneideVersion>7.2.3</seleneideVersion>
-        <seleniumJavaVersion>4.20.0</seleniumJavaVersion>
+        <seleniumJavaVersion>4.27.0</seleniumJavaVersion>
         <slf4jVersion>2.0.11</slf4jVersion>
         <testNGCucumberVersion>7.14.0</testNGCucumberVersion>
         <testNGVersion>7.8.0</testNGVersion>

--- a/qtaf-data/pom.xml
+++ b/qtaf-data/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.23</version>
+        <version>0.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-html-report-plugin/pom.xml
+++ b/qtaf-html-report-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.23</version>
+        <version>0.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-http/pom.xml
+++ b/qtaf-http/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.23</version>
+        <version>0.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -16,8 +16,8 @@
         <maven.compiler.target>17</maven.compiler.target>
         <!-- Dependency versions -->
         <jakartaActivationVersion>2.1.2</jakartaActivationVersion>
-        <jerseyClientVersion>3.1.6</jerseyClientVersion>
-        <jerseyMediaMultipartVersion>3.1.5</jerseyMediaMultipartVersion>
+        <jerseyClientVersion>3.1.7</jerseyClientVersion>
+        <jerseyMediaMultipartVersion>3.1.7</jerseyMediaMultipartVersion>
     </properties>
 
     <dependencies>

--- a/qtaf-io/pom.xml
+++ b/qtaf-io/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.23</version>
+        <version>0.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/qtaf-security/pom.xml
+++ b/qtaf-security/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.23</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>qtaf-security</artifactId>

--- a/qtaf-testrail-plugin/pom.xml
+++ b/qtaf-testrail-plugin/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.23</version>
+        <version>0.3.0</version>
     </parent>
 
     <artifactId>qtaf-testrail-plugin</artifactId>

--- a/qtaf-xray-plugin/pom.xml
+++ b/qtaf-xray-plugin/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>de.qytera</groupId>
         <artifactId>qtaf</artifactId>
-        <version>0.2.23</version>
+        <version>0.3.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
## Summary

First QTAF release in 19 months. Bundles dependency hardening and prepares the Maintenance-Mode reactivation strategy (see [ADR-0001](docs/adr/ADR-0001-selenium-manager-migration.md)).

## Dependency bumps

| Library | From | To | Type |
|---------|------|-----|------|
| Lombok | 1.18.30 | **1.18.38** | Java 21+ compat |
| Allure | 2.24.0 | **2.29.1** | 5 minors |
| Selenium | 4.20.0 | **4.27.0** | 7 minors |
| Pebble | 3.2.1 | **3.2.4** | 3 patches |
| Jersey client | 3.1.6 | **3.1.7** | patch |
| jersey-media-multipart | 3.1.5 | **3.1.7** | patch |

WebDriverManager intentionally **not bumped** — see ADR-0001 for the migration plan to Selenium Manager (built into Selenium 4.6+).

Project version **0.2.23 → 0.3.0** across all 11 modules.

## Consolidates

Replaces the following Dependabot PRs (closed in favour of this bundle):
- #315 Jersey 3.1.7
- #316 SLF4J 2.0.13 (outdated — Allure 2.29.1 already pulls newer SLF4J transitively)
- #318 Pebble 3.2.2 (superseded by 3.2.4)
- #326 Allure 2.28.1 (superseded by 2.29.1)
- #337 Lombok 1.18.34 (superseded by 1.18.38)

## README updates

- Marketing context: Google AI Overview citation 'DACH market leader for test automation with Open Source tools'
- Maintenance-Mode disclosure
- Successor track: qtaf-playwright-core (TypeScript/Playwright, Q3-2026)
- Sonar badge removed (token lost access after repo rename)
- URLs updated to lowercase repo slug

## Local test plan ✅

Apple Silicon, Java 17.0.19 (Homebrew openjdk@17), Maven 3.9.16:

```
mvn install -Dcheckstyle.skip=true -DexcludedGroups=ie,edge
```

Result: **575/575 tests green in 01:29 min** across all 11 modules.

## CI status

- Ubuntu Java 17: expected green (matches local sandbox setup)
- Windows: not in required status checks (see WebDriverManager+Chrome149 issue, permanent fix via ADR-0001)

## Post-merge

1. Tag `v0.3.0` on develop HEAD
2. GitHub Release page with changelog
3. Maven Central deploy as separate follow-up task (GPG-sign verification needed after 19 months)
4. ADR-0001 implementation (Selenium Manager migration) as next sprint

## Strategic context (QYQ-System)

- QTAF Maintenance-Mode + qtaf-playwright-core Dual-Track (forthcoming ADR-0024)
- Marketing reactivation asset for LLM-crawler visibility ('active open-source maintenance' signal)