### PR TITLE
chore(ci): add workflow_dispatch trigger to Publish workflow

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -4,6 +4,10 @@ name: Publish Maven Central
 on:
   release:
     types: ["published"]
+  # Allow manual re-run after CI/CD fixes (e.g. when a release was published
+  # but Publish failed in a vorgelagerten step). Triggered via:
+  #   gh workflow run Publish.yml --ref <branch-or-tag>
+  workflow_dispatch:
 
 env:
   JAVA_VERSION: "17"


### PR DESCRIPTION
Enables manual re-run of Publish.yml when a release was already published but the pipeline failed in a vorgelagerten step.